### PR TITLE
Fixed Incompatibility with Enhanced Weather Mod

### DIFF
--- a/src/main/java/com/github/alexnijjar/ad_astra/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/com/github/alexnijjar/ad_astra/mixin/client/WorldRendererMixin.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.github.alexnijjar.ad_astra.AdAstra;
 import com.github.alexnijjar.ad_astra.registry.ModParticleTypes;
+import com.github.alexnijjar.ad_astra.util.ModUtils;
 
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
@@ -63,6 +64,9 @@ public abstract class WorldRendererMixin {
 	// Venus rain.
 	@Inject(method = "tickRainSplashing", at = @At("HEAD"), cancellable = true)
 	public void adastra_tickRainSplashing(Camera camera, CallbackInfo info) {
+		if(!ModUtils.isPlanet(this.client.world)) {
+			info.cancel();
+		}
 		float f = this.client.world.getRainGradient(1.0F) / (MinecraftClient.isFancyGraphicsOrBetter() ? 1.0F : 2.0F);
 		if (!(f <= 0.0F)) {
 			RandomGenerator randomGenerator = RandomGenerator.createLegacy((long) this.ticks * 312987231L);


### PR DESCRIPTION
This pull request fixes an issue which causes the Venus Acid Rain smoke particles to appear in the Overworld when my mod rains. It fixes it by checking the world if it's one of the planets. If it's not, it doesn't produce the particles. I became aware of this bug's existence after [this issue](https://github.com/Talon396/EnhancedWeather/issues/1) was opened.