### PR TITLE
Add Venus Sandstone crushing into Venus Sand compatibility recipes

### DIFF
--- a/common/src/main/resources/data/ad_astra/tags/blocks/venus_sandstone.json
+++ b/common/src/main/resources/data/ad_astra/tags/blocks/venus_sandstone.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:venus_sandstone",
+    "ad_astra:venus_sandstone_bricks",
+    "ad_astra:cracked_venus_sandstone_bricks"
+  ]
+}

--- a/common/src/main/resources/data/ad_astra/tags/items/venus_sandstone.json
+++ b/common/src/main/resources/data/ad_astra/tags/items/venus_sandstone.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:venus_sandstone",
+    "ad_astra:venus_sandstone_bricks",
+    "ad_astra:cracked_venus_sandstone_bricks"
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/milling/venus_sandstone.json
+++ b/common/src/main/resources/data/create/recipes/milling/venus_sandstone.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:milling",
+  "ingredients": [
+    {
+      "tag": "ad_astra:venus_sandstone"
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:venus_sand"
+    }
+  ],
+  "processingTime": 150
+}

--- a/common/src/main/resources/data/minecraft/tags/blocks/stone_bricks.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/stone_bricks.json
@@ -9,8 +9,6 @@
     "ad_astra:cracked_mercury_stone_bricks",
     "ad_astra:venus_stone_bricks",
     "ad_astra:cracked_venus_stone_bricks",
-    "ad_astra:venus_sandstone_bricks",
-    "ad_astra:cracked_venus_sandstone_bricks",
     "ad_astra:glacio_stone_bricks",
     "ad_astra:cracked_glacio_stone_bricks",
     "ad_astra:chiseled_moon_stone_bricks",

--- a/common/src/main/resources/data/minecraft/tags/items/stone_bricks.json
+++ b/common/src/main/resources/data/minecraft/tags/items/stone_bricks.json
@@ -9,8 +9,6 @@
     "ad_astra:cracked_mercury_stone_bricks",
     "ad_astra:venus_stone_bricks",
     "ad_astra:cracked_venus_stone_bricks",
-    "ad_astra:venus_sandstone_bricks",
-    "ad_astra:cracked_venus_sandstone_bricks",
     "ad_astra:glacio_stone_bricks",
     "ad_astra:cracked_glacio_stone_bricks",
     "ad_astra:chiseled_moon_stone_bricks",

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:grinder",
+  "ingredients": [
+    {
+      "count": 1,
+      "tag": "ad_astra:venus_sandstone"
+    }
+  ],
+  "power": 4,
+  "results": [
+    {
+      "count": 4,
+      "item": "ad_astra:venus_sand"
+    }
+  ],
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone_brick_slab.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone_brick_slab.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:grinder",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:venus_sandstone_brick_slab"
+    }
+  ],
+  "power": 2,
+  "results": [
+    {
+      "count": 2,
+      "item": "ad_astra:venus_sand"
+    }
+  ],
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone_brick_stairs.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_grinder/venus_sand_from_venus_sandstone_brick_stairs.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:grinder",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:venus_sandstone_brick_stairs"
+    }
+  ],
+  "power": 3,
+  "results": [
+    {
+      "count": 3,
+      "item": "ad_astra:venus_sand"
+    }
+  ],
+  "time": 200
+}

--- a/forge/src/main/resources/data/forge/tags/blocks/sandstone.json
+++ b/forge/src/main/resources/data/forge/tags/blocks/sandstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:sandstone/venus_sandstone"
+  ]
+}

--- a/forge/src/main/resources/data/forge/tags/blocks/sandstone/venus_sandstone.json
+++ b/forge/src/main/resources/data/forge/tags/blocks/sandstone/venus_sandstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#ad_astra:venus_sandstone"
+  ]
+}

--- a/forge/src/main/resources/data/forge/tags/items/sandstone.json
+++ b/forge/src/main/resources/data/forge/tags/items/sandstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:sandstone/venus_sandstone"
+  ]
+}

--- a/forge/src/main/resources/data/forge/tags/items/sandstone/venus_sandstone.json
+++ b/forge/src/main/resources/data/forge/tags/items/sandstone/venus_sandstone.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#ad_astra:venus_sandstone"
+  ]
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/crusher/venus_sandstone.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/crusher/venus_sandstone.json
@@ -1,0 +1,25 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "immersiveengineering:crusher",
+	"energy": 3200,
+	"input": {
+		"tag": "forge:sandstone/venus_sandstone"
+	},
+	"result": {
+		"count": 2,
+		"item": "ad_astra:venus_sand"
+	},
+	"secondaries": [
+		{
+			"chance": 0.5,
+			"output": {
+				"tag": "forge:dusts/saltpeter"
+			}
+		}
+	]
+}

--- a/forge/src/main/resources/data/mekanism/recipes/crushing/venus_sandstone_to_venus_sand.json
+++ b/forge/src/main/resources/data/mekanism/recipes/crushing/venus_sandstone_to_venus_sand.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:crushing",
+	"input": {
+		"ingredient": {
+			"tag": "forge:sandstone/venus_sandstone"
+		}
+	},
+	"output": {
+		"count": 2,
+		"item": "ad_astra:venus_sand"
+	}
+}


### PR DESCRIPTION
## Summary

1. Added compatibility crushing recipe like vanilla sandstones.
2. Venus sandstone blocks be not included 'minecraft:stone_bricks' tag<br>in Tech Reborn, minecraft:stone_bricks tagged items can crushed into gravel.<br>Sandstones would crushing to be sand in my think

## Compatibility Mods

### Common

1. Create (Milling, Crushing)

![image](https://user-images.githubusercontent.com/44163945/203567514-38520f52-3162-4f2b-b805-710eae261f70.png)

### Fabric

1. Tech Reborn (Grinder)

![image](https://user-images.githubusercontent.com/44163945/203570167-6b8ff7e3-a267-4754-95b6-ef633d3b9bef.png)

### Forge

1. Immersive Engineering (Crusher)
1. Mekanism (Crusher)

![image](https://user-images.githubusercontent.com/44163945/203567568-8f6d9662-467f-4be9-9985-3873ff4ce6df.png)
