### PR TITLE
Add ingot compressing compatibility recipes

### DIFF
--- a/common/src/main/resources/data/create/recipes/pressing/calorite_ingot.json
+++ b/common/src/main/resources/data/create/recipes/pressing/calorite_ingot.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+      "tag": "ad_astra_platform:calorite_ingots"
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:calorite_plate",
+      "count": 1
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/pressing/desh_ingot.json
+++ b/common/src/main/resources/data/create/recipes/pressing/desh_ingot.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+      "tag": "ad_astra_platform:desh_ingots"
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:desh_plate",
+      "count": 1
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/pressing/ostrum_ingot.json
+++ b/common/src/main/resources/data/create/recipes/pressing/ostrum_ingot.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+      "tag": "ad_astra_platform:ostrum_ingots"
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:ostrum_plate",
+      "count": 1
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/pressing/steel_ingot.json
+++ b/common/src/main/resources/data/create/recipes/pressing/steel_ingot.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:pressing",
+  "ingredients": [
+    {
+      "tag": "ad_astra_platform:steel_ingots"
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:steel_plate",
+      "count": 1
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/calorite_ingot_to_plate.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/calorite_ingot_to_plate.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:compressor",
+  "duration": 200,
+  "eu": 2,
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "c:calorite_ingots"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:calorite_plate"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/desh_ingot_to_plate.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/desh_ingot_to_plate.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:compressor",
+  "duration": 200,
+  "eu": 2,
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "c:desh_ingots"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:desh_plate"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/ostrum_ingot_to_plate.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/compressor/ostrum_ingot_to_plate.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:compressor",
+  "duration": 200,
+  "eu": 2,
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "c:ostrum_ingots"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:ostrum_plate"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/compressing/calorite_plate_from_block.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/compressing/calorite_plate_from_block.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:compressor",
+  "power": 2,
+  "time": 400,
+  "ingredients": [
+    {
+      "tag": "c:calorite_blocks",
+      "count": 1
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:calorite_plate",
+      "count": 9
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/compressing/desh_plate_from_block.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/compressing/desh_plate_from_block.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:compressor",
+  "power": 2,
+  "time": 400,
+  "ingredients": [
+    {
+      "tag": "c:desh_blocks",
+      "count": 1
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:desh_plate",
+      "count": 9
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/compressing/ostrum_plate_from_block.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/compressing/ostrum_plate_from_block.json
@@ -1,0 +1,25 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:compressor",
+  "power": 2,
+  "time": 400,
+  "ingredients": [
+    {
+      "tag": "c:ostrum_blocks",
+      "count": 1
+    }
+  ],
+  "results": [
+    {
+      "item": "ad_astra:ostrum_plate",
+      "count": 9
+    }
+  ]
+}

--- a/forge/src/main/resources/data/forge/tags/items/plates.json
+++ b/forge/src/main/resources/data/forge/tags/items/plates.json
@@ -1,0 +1,8 @@
+{
+  "values": [
+    "#forge:plates/calorite",
+    "#forge:plates/desh",
+    "#forge:plates/ostrum",
+    "#forge:plates/steel"
+  ]
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_calorite_hammering.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_calorite_hammering.json
@@ -1,0 +1,20 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "minecraft:crafting_shapeless",
+	"ingredients": [
+		{
+			"tag": "forge:ingots/calorite"
+		},
+		{
+			"item": "immersiveengineering:hammer"
+		}
+	],
+	"result": {
+		"item": "ad_astra:calorite_plate"
+	}
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_desh_hammering.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_desh_hammering.json
@@ -1,0 +1,20 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "minecraft:crafting_shapeless",
+	"ingredients": [
+		{
+			"tag": "forge:ingots/desh"
+		},
+		{
+			"item": "immersiveengineering:hammer"
+		}
+	],
+	"result": {
+		"item": "ad_astra:desh_plate"
+	}
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_ostrum_hammering.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/crafting/plate_ostrum_hammering.json
@@ -1,0 +1,20 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "minecraft:crafting_shapeless",
+	"ingredients": [
+		{
+			"tag": "forge:ingots/ostrum"
+		},
+		{
+			"item": "immersiveengineering:hammer"
+		}
+	],
+	"result": {
+		"item": "ad_astra:ostrum_plate"
+	}
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_calorite.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_calorite.json
@@ -1,0 +1,17 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "immersiveengineering:metal_press",
+	"energy": 2400,
+	"input": {
+		"tag": "forge:ingots/calorite"
+	},
+	"mold": "immersiveengineering:mold_plate",
+	"result": {
+		"tag": "forge:plates/calorite"
+	}
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_desh.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_desh.json
@@ -1,0 +1,17 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "immersiveengineering:metal_press",
+	"energy": 2400,
+	"input": {
+		"tag": "forge:ingots/desh"
+	},
+	"mold": "immersiveengineering:mold_plate",
+	"result": {
+		"tag": "forge:plates/desh"
+	}
+}

--- a/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_ostrum.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/metalpress/plate_ostrum.json
@@ -1,0 +1,17 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "immersiveengineering:metal_press",
+	"energy": 2400,
+	"input": {
+		"tag": "forge:ingots/ostrum"
+	},
+	"mold": "immersiveengineering:mold_plate",
+	"result": {
+		"tag": "forge:plates/ostrum"
+	}
+}


### PR DESCRIPTION
## Summary

1. Added forge:plates tag.
1. Added making plate compatibility recipes.

## Compatibility Mods

### Common

1. Create (Pressing)

![image](https://user-images.githubusercontent.com/44163945/203575247-fce48ad5-10dc-4430-8b37-821087c9c0aa.png)

### Fabric

1. Tech Reborn (Compressor: Block to 9x Plates)
    Ingot recipes had already added.
2. Modern Industrialization (Compressor)

![image](https://user-images.githubusercontent.com/44163945/203574132-0ab7cd9d-2a06-49e8-b184-985bf1664765.png)
![image](https://user-images.githubusercontent.com/44163945/203574824-65a61e09-63ad-4e22-93c3-695cb197d7d0.png)

### Forge

1. Immersive Engineering (Hammering, Metalpress)

![image](https://user-images.githubusercontent.com/44163945/203576806-370bccf7-4eb1-4147-ae09-9b57a8e1a31c.png)
![image](https://user-images.githubusercontent.com/44163945/203576816-f3c05241-a879-479b-a9c2-c6a2adda21f1.png)

