### PR TITLE
Copy NBT to result item on crafting spacesuit

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/recipes/SpaceSuitShapedRecipe.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/recipes/SpaceSuitShapedRecipe.java
@@ -1,0 +1,147 @@
+package earth.terrarium.ad_astra.recipes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import com.google.gson.JsonObject;
+
+import earth.terrarium.ad_astra.items.FluidContainingItem;
+import earth.terrarium.ad_astra.registry.ModRecipeSerializers;
+import earth.terrarium.ad_astra.registry.ModTags;
+import earth.terrarium.botarium.api.fluid.FluidHolder;
+import earth.terrarium.botarium.api.fluid.FluidHooks;
+import earth.terrarium.botarium.api.item.ItemStackHolder;
+import net.minecraft.data.recipes.FinishedRecipe;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.inventory.CraftingContainer;
+import net.minecraft.world.item.ArmorItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeSerializer;
+import net.minecraft.world.item.crafting.ShapedRecipe;
+import net.minecraft.world.level.material.Fluid;
+
+public class SpaceSuitShapedRecipe extends ShapedRecipe {
+
+    public SpaceSuitShapedRecipe(ShapedRecipe internal) {
+        super(internal.getId(), internal.getGroup(), internal.getWidth(), internal.getHeight(),
+                internal.getIngredients(), internal.getResultItem());
+    }
+
+    public static Consumer<FinishedRecipe> wrap(Consumer<FinishedRecipe> exporter) {
+        return r -> exporter.accept(new WrappedFinishedRecipe(r));
+    }
+
+    @Override
+    public ItemStack assemble(CraftingContainer inv) {
+        ItemStack assemble = super.assemble(inv).copy();
+        CompoundTag assemblingTag = null;
+        Map<Fluid, FluidHolder> assemblingOxygens = new HashMap<>();
+
+        for (int i = 0; i < inv.getContainerSize(); i++) {
+            ItemStack item = inv.getItem(i);
+            if (item.isEmpty()) {
+                continue;
+            } else if (item.getItem() instanceof ArmorItem) {
+                assemblingTag = item.getTag();
+            } else {
+                FluidHooks.safeGetItemFluidManager(item).ifPresent(fluidManager -> {
+                    this.mergeOxygen(assemblingOxygens, fluidManager.getFluidInTank(0));
+                });
+            }
+        }
+
+        if (assemblingTag != null) {
+            assemble.setTag(assemblingTag.copy());
+        }
+
+        if (assemblingOxygens.size() > 0 && assemble.getItem() instanceof FluidContainingItem fluidContaining) {
+            ItemStackHolder itemHolder = new ItemStackHolder(assemble);
+
+            Fluid primaryFluid = assemblingOxygens.entrySet().stream().max(this::compareAmount).map(e -> e.getKey()).orElse(null);
+            long totalOxygen = assemblingOxygens.values().stream().collect(Collectors.summingLong(e -> e.getFluidAmount()));
+            fluidContaining.insert(itemHolder, FluidHooks.newFluidHolder(primaryFluid, totalOxygen, null));
+
+            if (itemHolder.isDirty()) assemble = itemHolder.getStack();
+        }
+
+        return assemble.copy();
+    }
+
+    @SuppressWarnings("deprecation")
+    private void mergeOxygen(Map<Fluid, FluidHolder> map, FluidHolder merging) {
+        Fluid fluid = merging.getFluid();
+        if (fluid.is(ModTags.OXYGEN)) {
+            FluidHolder current = map.computeIfAbsent(fluid, f -> FluidHooks.newFluidHolder(f, 0L, null));
+            current.setAmount(current.getFluidAmount() + merging.getFluidAmount());
+        }
+    }
+
+    private int compareAmount(Entry<Fluid, FluidHolder> entry1, Entry<Fluid, FluidHolder> entry2) {
+        return Long.compare(entry1.getValue().getFluidAmount(), entry2.getValue().getFluidAmount());
+    }
+
+    public static class WrappedFinishedRecipe implements FinishedRecipe {
+
+        private final FinishedRecipe internal;
+
+        public WrappedFinishedRecipe(FinishedRecipe internal) {
+            this.internal = internal;
+        }
+
+        public FinishedRecipe getInternal() {
+            return this.internal;
+        }
+
+        @Override
+        public ResourceLocation getAdvancementId() {
+            return this.getInternal().getAdvancementId();
+        }
+
+        @Override
+        public ResourceLocation getId() {
+            return this.getInternal().getId();
+        }
+
+        @Override
+        public RecipeSerializer<?> getType() {
+            return ModRecipeSerializers.SPACE_SUIT_CRAFTING_SERIALIZER.get();
+        }
+
+        @Override
+        public JsonObject serializeAdvancement() {
+            return this.getInternal().serializeAdvancement();
+        }
+
+        @Override
+        public void serializeRecipeData(JsonObject json) {
+            this.getInternal().serializeRecipeData(json);
+        }
+    }
+
+    public static class Serializer implements RecipeSerializer<SpaceSuitShapedRecipe> {
+
+        @Override
+        public SpaceSuitShapedRecipe fromJson(ResourceLocation recipeId, JsonObject json) {
+            return new SpaceSuitShapedRecipe(this.getWrappedSerializer().fromJson(recipeId, json));
+        }
+
+        @Override
+        public SpaceSuitShapedRecipe fromNetwork(ResourceLocation recipeId, FriendlyByteBuf buffer) {
+            return new SpaceSuitShapedRecipe(this.getWrappedSerializer().fromNetwork(recipeId, buffer));
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buffer, SpaceSuitShapedRecipe recipe) {
+            this.getWrappedSerializer().toNetwork(buffer, recipe);
+        }
+
+        private RecipeSerializer<ShapedRecipe> getWrappedSerializer() {
+            return RecipeSerializer.SHAPED_RECIPE;
+        }
+    }
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/registry/ModRecipeSerializers.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/registry/ModRecipeSerializers.java
@@ -17,6 +17,7 @@ public class ModRecipeSerializers {
     public static final Supplier<RecipeSerializer<FluidConversionRecipe>> FUEL_CONVERSION_SERIALIZER = register("fuel_conversion", () -> new CodecRecipeSerializer<>(ModRecipeTypes.FUEL_CONVERSION_RECIPE.get(), FluidConversionRecipe::codec));
     public static final Supplier<RecipeSerializer<OxygenConversionRecipe>> OXYGEN_CONVERSION_SERIALIZER = register("oxygen_conversion", () -> new CodecRecipeSerializer<>(ModRecipeTypes.OXYGEN_CONVERSION_RECIPE.get(), OxygenConversionRecipe::oxygenCodec));
     public static final Supplier<RecipeSerializer<CryoFuelConversionRecipe>> CRYO_FUEL_CONVERSION_SERIALIZER = register("cryo_fuel_conversion", () -> new CodecRecipeSerializer<>(ModRecipeTypes.CRYO_FUEL_CONVERSION_RECIPE.get(), CryoFuelConversionRecipe::codec));
+    public static final Supplier<SpaceSuitShapedRecipe.Serializer> SPACE_SUIT_CRAFTING_SERIALIZER = register("crafting_shaped_space_suit", () -> new SpaceSuitShapedRecipe.Serializer());
 
     private static <T extends RecipeSerializer<E>, E extends Recipe<?>> Supplier<T> register(String id, Supplier<T> object) {
         return ModRegistryHelpers.register(Registry.RECIPE_SERIALIZER, id, object);

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:calorite_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_boots.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_boots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:calorite_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_helmet.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_helmet.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:calorite_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_pants.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/jet_suit_pants.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:calorite_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_boots.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_boots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:ostrum_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_helmet.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_helmet.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:ostrum_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_pants.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_pants.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:ostrum_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_suit.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/netherite_space_suit.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:ostrum_plates"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/space_boots.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/space_boots.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:steel_ingots"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/space_helmet.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/space_helmet.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:steel_ingots"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/space_pants.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/space_pants.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:steel_ingots"

--- a/common/src/main/resources/data/ad_astra/recipes/recipes/space_suit.json
+++ b/common/src/main/resources/data/ad_astra/recipes/recipes/space_suit.json
@@ -1,5 +1,5 @@
 {
-  "type": "minecraft:crafting_shaped",
+  "type": "ad_astra:crafting_shaped_space_suit",
   "key": {
     "#": {
       "tag": "ad_astra_platform:steel_ingots"

--- a/fabric/src/main/java/earth/terrarium/ad_astra/datagen/ModRecipeProvider.java
+++ b/fabric/src/main/java/earth/terrarium/ad_astra/datagen/ModRecipeProvider.java
@@ -1,5 +1,6 @@
 package earth.terrarium.ad_astra.datagen;
 
+import earth.terrarium.ad_astra.recipes.SpaceSuitShapedRecipe;
 import earth.terrarium.ad_astra.registry.ModBlocks;
 import earth.terrarium.ad_astra.registry.ModItems;
 import earth.terrarium.ad_astra.registry.ModTags;
@@ -451,44 +452,46 @@ class ModRecipeProvider extends FabricRecipeProvider {
         ShapelessRecipeBuilder.shapeless(Items.FLINT_AND_STEEL).requires(ModTags.STEEL_INGOTS).requires(Items.FLINT).unlockedBy("has_flint", has(Items.FLINT)).unlockedBy("has_obsidian", has(Blocks.OBSIDIAN)).save(exporter);
 
         // Armour
+        Consumer<FinishedRecipe> spaceSuitExporter = SpaceSuitShapedRecipe.wrap(exporter);
         ShapedRecipeBuilder.shaped(ModItems.SPACE_HELMET.get()).define('#', ModTags.STEEL_INGOTS).define('G', Blocks.ORANGE_STAINED_GLASS_PANE).pattern("###").pattern("#G#").group(null)
-                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(exporter);
+                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.SPACE_SUIT.get()).define('#', ModTags.STEEL_INGOTS).define('W', Blocks.WHITE_WOOL).define('O', ModItems.OXYGEN_GEAR.get())
-                .define('T', ModItems.OXYGEN_TANK.get()).pattern("# #").pattern("TOT").pattern("#W#").group(null).unlockedBy(getHasName(ModItems.STEEL_INGOT.get()), has(ModItems.STEEL_INGOT.get())).save(exporter);
+                .define('T', ModItems.OXYGEN_TANK.get()).pattern("# #").pattern("TOT").pattern("#W#").group(null)
+                .unlockedBy(getHasName(ModItems.STEEL_INGOT.get()), has(ModItems.STEEL_INGOT.get())).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.SPACE_PANTS.get()).define('#', ModTags.STEEL_INGOTS).define('W', Blocks.WHITE_WOOL).pattern("###").pattern("W W").pattern("# #").group(null)
-                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(exporter);
+                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.SPACE_BOOTS.get()).define('#', ModTags.STEEL_INGOTS).define('W', Blocks.WHITE_WOOL).pattern("W W").pattern("# #").group(null)
-                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(exporter);
+                .unlockedBy("has_tag", has(ModTags.STEEL_INGOTS)).save(spaceSuitExporter);
 
         // Netherite
         ShapedRecipeBuilder.shaped(ModItems.NETHERITE_SPACE_HELMET.get()).define('#', ModTags.OSTRUM_PLATES).define('N', Items.NETHERITE_HELMET).define('G', Blocks.ORANGE_STAINED_GLASS_PANE)
-                .pattern("#N#").pattern("#G#").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(exporter);
+                .pattern("#N#").pattern("#G#").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.NETHERITE_SPACE_SUIT.get()).define('#', ModTags.OSTRUM_PLATES).define('N', Items.NETHERITE_CHESTPLATE).define('O', ModItems.OXYGEN_GEAR.get())
-                .define('T', ModItems.OXYGEN_TANK.get()).pattern("# #").pattern("TOT").pattern("#N#").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(exporter);
+                .define('T', ModItems.OXYGEN_TANK.get()).pattern("# #").pattern("TOT").pattern("#N#").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.NETHERITE_SPACE_PANTS.get()).define('#', ModTags.OSTRUM_PLATES).define('N', Items.NETHERITE_LEGGINGS).define('D', ModTags.DESH_PLATES).pattern("#N#")
-                .pattern("D D").pattern("# #").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(exporter);
+                .pattern("D D").pattern("# #").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.NETHERITE_SPACE_BOOTS.get()).define('#', ModTags.OSTRUM_PLATES).define('N', Items.NETHERITE_BOOTS).define('D', ModTags.DESH_PLATES).pattern(" N ")
-                .pattern("D D").pattern("# #").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(exporter);
+                .pattern("D D").pattern("# #").group(null).unlockedBy("has_tag", has(ModTags.OSTRUM_PLATES)).save(spaceSuitExporter);
 
         // Jet Suit
         ShapedRecipeBuilder.shaped(ModItems.JET_SUIT_HELMET.get()).define('#', ModTags.CALORITE_PLATES).define('N', ModItems.NETHERITE_SPACE_HELMET.get()).define('G', Blocks.ORANGE_STAINED_GLASS)
-                .pattern("#N#").pattern("#G#").group(null).unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(exporter);
+                .pattern("#N#").pattern("#G#").group(null).unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.JET_SUIT.get()).define('#', ModTags.CALORITE_PLATES).define('B', ModTags.CALORITE_BLOCKS).define('N', ModItems.NETHERITE_SPACE_SUIT.get())
-                .define('E', ModItems.CALORITE_ENGINE.get()).define('T', ModItems.CALORITE_TANK.get()).pattern("# #").pattern("TNT").pattern("BEB").group(null).unlockedBy("has_tag", has(ModTags.CALORITE_PLATES))
-                .save(exporter);
+                .define('E', ModItems.CALORITE_ENGINE.get()).define('T', ModItems.CALORITE_TANK.get()).pattern("# #").pattern("TNT").pattern("BEB").group(null)
+                .unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.JET_SUIT_PANTS.get()).define('#', ModTags.CALORITE_PLATES).define('N', ModItems.NETHERITE_SPACE_PANTS.get()).pattern("#N#").pattern("# #").pattern("# #").group(null)
-                .unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(exporter);
+                .unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(spaceSuitExporter);
 
         ShapedRecipeBuilder.shaped(ModItems.JET_SUIT_BOOTS.get()).define('#', ModTags.CALORITE_PLATES).define('B', ModTags.CALORITE_BLOCKS).define('N', ModItems.NETHERITE_SPACE_BOOTS.get())
-                .pattern(" N ").pattern("# #").pattern("B B").group(null).unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(exporter);
+                .pattern(" N ").pattern("# #").pattern("B B").group(null).unlockedBy("has_tag", has(ModTags.CALORITE_PLATES)).save(spaceSuitExporter);
 
         // Soul Torch
         ShapedRecipeBuilder.shaped(Items.SOUL_TORCH).define('#', ModItems.EXTINGUISHED_TORCH.get()).define('S', Items.SOUL_SOIL).pattern("S").pattern("#")


### PR DESCRIPTION
### Summary

An another idea for solve issue #28
Just an idea.
I don't care, even if ignore this.

### Changes

1. Declare custom shaped crafting recipe type, SpaceSuitRecipe.
2. Change recipe serializer as 'ad_astra:crafting_shaped_space_suit' in recipe file.
3. It recipe type will do these.
    Copy armor ingredient item's NBT data to result item.
    Merge oxygen to result item from ingredients.

### Examples

Copy enchantments
![image](https://user-images.githubusercontent.com/44163945/204039050-75a441c5-86c2-42f6-af14-4b7825650b39.png)

Copy custom name and merge oxygen
![image](https://user-images.githubusercontent.com/44163945/204039057-04f0ff9a-b7af-48f0-80d1-950564df7db7.png)

Keep NBT tags
![image](https://user-images.githubusercontent.com/44163945/204039064-f16dec02-a8ad-405f-942e-053c17eea46f.png)
