### PR TITLE
Glacian Ram be support shear-like item in Forge

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/entities/mobs/GlacianRam.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/entities/mobs/GlacianRam.java
@@ -1,5 +1,8 @@
 package earth.terrarium.ad_astra.entities.mobs;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.jetbrains.annotations.Nullable;
 import earth.terrarium.ad_astra.entities.mobs.goal.EatPermafrostGoal;
 import earth.terrarium.ad_astra.registry.ModBlocks;
 import earth.terrarium.ad_astra.registry.ModEntityTypes;
@@ -123,8 +126,7 @@ public class GlacianRam extends Animal implements Shearable {
         ItemStack itemStack = player.getItemInHand(hand);
         if (itemStack.is(Items.SHEARS)) {
             if (!this.level.isClientSide && this.readyForShearing()) {
-                this.shear(SoundSource.PLAYERS);
-                this.gameEvent(GameEvent.SHEAR, player);
+                this.shear(player, SoundSource.PLAYERS);
                 itemStack.hurtAndBreak(1, player, playerx -> playerx.broadcastBreakEvent(hand));
                 return InteractionResult.SUCCESS;
             } else {
@@ -137,17 +139,28 @@ public class GlacianRam extends Animal implements Shearable {
 
     @Override
     public void shear(SoundSource shearedSoundCategory) {
-        this.level.playSound(null, this, SoundEvents.SHEEP_SHEAR, shearedSoundCategory, 1.0F, 1.0F);
-        this.setSheared(true);
-        int i = 1 + this.random.nextInt(3);
+        this.shear(null, shearedSoundCategory);
+    }
 
-        for (int j = 0; j < i; ++j) {
-            ItemEntity itemEntity = this.spawnAtLocation(ModBlocks.GLACIAN_FUR.get());
+    public void shear(@Nullable Player player, SoundSource shearedSoundCategory) {
+        for (ItemStack item : this.onSheared(player, shearedSoundCategory)) {
+            ItemEntity itemEntity = this.spawnAtLocation(item);
             if (itemEntity != null) {
                 itemEntity.setDeltaMovement(itemEntity.getDeltaMovement().add((this.random.nextFloat() - this.random.nextFloat()) * 0.1F, this.random.nextFloat() * 0.05F, (this.random.nextFloat() - this.random.nextFloat()) * 0.1F));
             }
         }
+    }
 
+    public List<ItemStack> onSheared(@Nullable Player player, SoundSource shearedSoundCategory) {
+        this.level.playSound(null, this, SoundEvents.SHEEP_SHEAR, shearedSoundCategory, 1.0F, 1.0F);
+        if (player != null) this.gameEvent(GameEvent.SHEAR, player);
+        this.setSheared(true);
+        int i = 1 + this.random.nextInt(3);
+        List<ItemStack> items = new ArrayList<>();
+        for (int j = 0; j < i; ++j) {
+            items.add(new ItemStack(ModBlocks.GLACIAN_FUR.get()));
+        }
+        return items;
     }
 
     @Override

--- a/forge/src/main/java/earth/terrarium/ad_astra/mixin/forge/GlacianRamMixin.java
+++ b/forge/src/main/java/earth/terrarium/ad_astra/mixin/forge/GlacianRamMixin.java
@@ -1,0 +1,36 @@
+package earth.terrarium.ad_astra.mixin.forge;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+
+import earth.terrarium.ad_astra.entities.mobs.GlacianRam;
+import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.IForgeShearable;
+
+@Mixin(GlacianRam.class)
+public abstract class GlacianRamMixin extends Animal implements IForgeShearable {
+    protected GlacianRamMixin(EntityType<? extends GlacianRam> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    @Override
+    public boolean isShearable(@NotNull ItemStack item, Level level, BlockPos pos) {
+        GlacianRam self = (GlacianRam) (Object) this;
+        return self.readyForShearing();
+    }
+
+    @Override
+    public @NotNull List<ItemStack> onSheared(@Nullable Player player, @NotNull ItemStack item, Level level, BlockPos pos, int fortune) {
+        GlacianRam self = (GlacianRam) (Object) this;
+        return self.onSheared(player, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
+    }
+}

--- a/forge/src/main/resources/ad_astra.mixins.json
+++ b/forge/src/main/resources/ad_astra.mixins.json
@@ -10,6 +10,7 @@
   ],
   "mixins": [
     "AxeItemAccessor",
+    "GlacianRamMixin",
     "JetSuitMixin"
   ],
   "injectors": {


### PR DESCRIPTION
## Summary

1. Shear-like item be can shear Glacian Ram in Forge. (e.g. Meka-Tool)
2. Fabric features not changed.

## Example

![Shear](https://user-images.githubusercontent.com/44163945/204077334-1b1c6500-743c-417f-a3e5-4e8307171ea8.gif)

