### PR TITLE
Add ice shard ores crushing compatibility recipes to forge

### DIFF
--- a/forge/src/main/resources/data/immersiveengineering/recipes/crusher/ice_shard.json
+++ b/forge/src/main/resources/data/immersiveengineering/recipes/crusher/ice_shard.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "immersiveengineering"
+		}
+	],
+	"type": "immersiveengineering:crusher",
+	"energy": 3200,
+	"input": {
+		"tag": "forge:ores/ice_shard"
+	},
+	"result": {
+		"count": 4,
+		"item": "ad_astra:ice_shard"
+	},
+	"secondaries": []
+}

--- a/forge/src/main/resources/data/mekanism/recipes/enriching/ice_shard_or_to_ice_shards.json
+++ b/forge/src/main/resources/data/mekanism/recipes/enriching/ice_shard_or_to_ice_shards.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:enriching",
+	"input": {
+		"ingredient": {
+			"tag": "forge:ores/ice_shard"
+		}
+	},
+	"output": {
+		"count": 4,
+		"item": "ad_astra:ice_shard"
+	}
+}


### PR DESCRIPTION
Result shards count 4 was referenced at fabric compatibility recipes.

Immersive Engineering
![image](https://user-images.githubusercontent.com/44163945/204081773-2b9eaf12-a3a6-4b07-b9f8-adafa65e5118.png)

Mekanism
![image](https://user-images.githubusercontent.com/44163945/204081774-38e181bb-7c32-4383-b078-843df834d425.png)
