### PR TITLE
Add transfer tooltip to cable/pipe blocks

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/block/pipe/CableBlock.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/block/pipe/CableBlock.java
@@ -2,11 +2,17 @@ package earth.terrarium.ad_astra.block.pipe;
 
 import earth.terrarium.ad_astra.registry.ModSoundEvents;
 import earth.terrarium.botarium.api.energy.EnergyHooks;
+import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -20,6 +26,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class CableBlock extends AbstractPipeBlock {
@@ -47,6 +54,12 @@ public class CableBlock extends AbstractPipeBlock {
         super(transferRate, decay, size, settings);
         this.registerDefaultState(defaultBlockState().setValue(UP, false).setValue(DOWN, false).setValue(NORTH, false).setValue(EAST, false).setValue(SOUTH, false).setValue(WEST, false).setValue(WATERLOGGED, false));
         this.stateDefinition.getPossibleStates().forEach(state -> shapes.put(state, this.createShape(state)));
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, BlockGetter level, List<Component> tooltip, TooltipFlag flag) {
+        super.appendHoverText(stack, level, tooltip, flag);
+        tooltip.add((Component.translatable("item.ad_astra.energy_transfer_rate.tooltip", this.getTransferRate()).setStyle(Style.EMPTY.withColor(ChatFormatting.BLUE))));
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/ad_astra/block/pipe/FluidPipeBlock.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/block/pipe/FluidPipeBlock.java
@@ -2,12 +2,17 @@ package earth.terrarium.ad_astra.block.pipe;
 
 import earth.terrarium.ad_astra.registry.ModSoundEvents;
 import earth.terrarium.botarium.api.fluid.FluidHooks;
+import net.minecraft.ChatFormatting;
 import net.minecraft.Util;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.Style;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.TooltipFlag;
+import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -20,6 +25,7 @@ import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FluidPipeBlock extends AbstractPipeBlock {
@@ -46,6 +52,12 @@ public class FluidPipeBlock extends AbstractPipeBlock {
         super(transferRate, decay, size, settings);
         this.registerDefaultState(defaultBlockState().setValue(UP, PipeState.NONE).setValue(DOWN, PipeState.NONE).setValue(NORTH, PipeState.NONE).setValue(EAST, PipeState.NONE).setValue(SOUTH, PipeState.NONE).setValue(WEST, PipeState.NONE).setValue(WATERLOGGED, false));
         this.stateDefinition.getPossibleStates().forEach(state -> shapes.put(state, this.createShape(state)));
+    }
+
+    @Override
+    public void appendHoverText(ItemStack stack, BlockGetter level, List<Component> tooltip, TooltipFlag flag) {
+        super.appendHoverText(stack, level, tooltip, flag);
+        tooltip.add((Component.translatable("item.ad_astra.fluid_transfer_rate.tooltip", this.getTransferRate()).setStyle(Style.EMPTY.withColor(ChatFormatting.BLUE))));
     }
 
     @Override

--- a/common/src/main/resources/assets/ad_astra/lang/en_us.json
+++ b/common/src/main/resources/assets/ad_astra/lang/en_us.json
@@ -466,6 +466,7 @@
   "item.ad_astra.engine_fan": "Engine Fan",
   "item.ad_astra.engine_frame": "Engine Frame",
   "item.ad_astra.flag.tooltip": "Right-click the block to set an image URL",
+  "item.ad_astra.energy_transfer_rate.tooltip": "Energy Transfer: %s ⚡/t",
   "item.ad_astra.fluid_transfer_rate.tooltip": "Fluid Transfer: %s 🪣/t",
   "item.ad_astra.fuel_bucket": "Fuel Bucket",
   "item.ad_astra.fuel_refinery.tooltip": "Converts oil into fuel.",

--- a/common/src/main/resources/assets/ad_astra/lang/ko_kr.json
+++ b/common/src/main/resources/assets/ad_astra/lang/ko_kr.json
@@ -466,6 +466,7 @@
   "item.ad_astra.engine_fan": "엔진 날개",
   "item.ad_astra.engine_frame": "엔진 프레임",
   "item.ad_astra.flag.tooltip": "깃대를 우클릭해서 이미지를 보여주도록 설정할 수 있습니다",
+  "item.ad_astra.energy_transfer_rate.tooltip": "에너지 전송: %s ⚡/t",
   "item.ad_astra.fluid_transfer_rate.tooltip": "유체 전송: %s 🪣/틱",
   "item.ad_astra.fuel_bucket": "연료 양동이",
   "item.ad_astra.fuel_refinery.tooltip": "원유를 연료로 정제합니다.",


### PR DESCRIPTION
I think be better to show transfer amount

![image](https://user-images.githubusercontent.com/44163945/206830721-e97cb55e-0429-4600-84f0-3b9a7e6ece17.png)
![image](https://user-images.githubusercontent.com/44163945/206830724-e8402e25-223a-47c1-841e-6d670f5fdee5.png)
