### PR TITLE
Forge support more wrench tags

### DIFF
--- a/forge/src/main/resources/data/forge/tags/items/wrenches.json
+++ b/forge/src/main/resources/data/forge/tags/items/wrenches.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "ad_astra:wrench"
+    "#forge:tools/wrench"
   ]
 }


### PR DESCRIPTION
Some mod wrenches tagged only `'forge:tools/wrench'` without `'forge:wrenches'`.
e.g. AE2 quartz_wrench.

So i  make `'forge:wrenches'` be include `'forge:tools/wrench'`