### PR TITLE
REI/JEI support 'Move Items' for quick craft

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/AdAstraJeiPlugin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/AdAstraJeiPlugin.java
@@ -4,16 +4,21 @@ import earth.terrarium.ad_astra.AdAstra;
 import earth.terrarium.ad_astra.client.screen.*;
 import earth.terrarium.ad_astra.common.compat.jei.category.*;
 import earth.terrarium.ad_astra.common.compat.jei.guihandler.*;
+import earth.terrarium.ad_astra.common.compat.jei.transfer.*;
 import earth.terrarium.ad_astra.common.registry.ModItems;
+import earth.terrarium.ad_astra.common.registry.ModMenuTypes;
 import earth.terrarium.ad_astra.common.registry.ModRecipeTypes;
+import earth.terrarium.ad_astra.common.screen.menu.*;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.helpers.IGuiHelper;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandlerHelper;
 import mezz.jei.api.registration.IGuiHandlerRegistration;
 import mezz.jei.api.registration.IModIngredientRegistration;
 import mezz.jei.api.registration.IRecipeCatalystRegistration;
 import mezz.jei.api.registration.IRecipeCategoryRegistration;
 import mezz.jei.api.registration.IRecipeRegistration;
+import mezz.jei.api.registration.IRecipeTransferRegistration;
 import net.minecraft.client.Minecraft;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.Level;
@@ -68,5 +73,18 @@ public class AdAstraJeiPlugin implements IModPlugin {
         registration.addGuiContainerHandler(ConversionScreen.class, new OxygenConversionGuiContainerHandler());
         registration.addGuiContainerHandler(OxygenDistributorScreen.class, new OxygenDistributorGuiContainerHandler());
         registration.addGuiContainerHandler(CryoFreezerScreen.class, new CryoFreezerGuiContainerHandler());
+    }
+
+    @Override
+    public void registerRecipeTransferHandlers(IRecipeTransferRegistration registration) {
+        IRecipeTransferHandlerHelper transferHelper = registration.getTransferHelper();
+        registration.addRecipeTransferHandler(new MachineTransferInfo<>(CompressorMenu.class, ModMenuTypes.COMPRESSOR_MENU.get(), CompressorCategory.RECIPE));
+        registration.addRecipeTransferHandler(new NotifyableTransferHandler<>(transferHelper.createUnregisteredRecipeTransferHandler(new MachineTransferInfo<>(NasaWorkbenchMenu.class, ModMenuTypes.NASA_WORKBENCH_MENU.get(), NasaWorkbenchCategory.RECIPE) {
+            @Override
+            protected int getInputSlotCount(NasaWorkbenchMenu menu) {
+                return 14;
+            }
+        })), NasaWorkbenchCategory.RECIPE);
+        registration.addRecipeTransferHandler(new MachineTransferInfo<>(CryoFreezerMenu.class, ModMenuTypes.CRYO_FREEZER_MENU.get(), CryoFuelConversionCategory.RECIPE));
     }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/transfer/MachineTransferInfo.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/transfer/MachineTransferInfo.java
@@ -1,0 +1,61 @@
+package earth.terrarium.ad_astra.common.compat.jei.transfer;
+
+import java.util.List;
+import java.util.Optional;
+
+import earth.terrarium.ad_astra.common.block.machine.entity.AbstractMachineBlockEntity;
+import earth.terrarium.ad_astra.common.screen.menu.AbstractMachineMenu;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
+import net.minecraft.world.inventory.MenuType;
+import net.minecraft.world.inventory.Slot;
+
+public class MachineTransferInfo<MENU extends AbstractMachineMenu<? extends AbstractMachineBlockEntity>, RECIPE> implements IRecipeTransferInfo<MENU, RECIPE> {
+
+    private final Class<MENU> menuClass;
+    private final MenuType<MENU> menuType;
+    private final RecipeType<RECIPE> recipeType;
+
+    public MachineTransferInfo(Class<MENU> menuClass, MenuType<MENU> menuType, RecipeType<RECIPE> recipeType) {
+        this.menuClass = menuClass;
+        this.menuType = menuType;
+        this.recipeType = recipeType;
+    }
+
+    @Override
+    public Class<? extends MENU> getContainerClass() {
+        return this.menuClass;
+    }
+
+    @Override
+    public Optional<MenuType<MENU>> getMenuType() {
+        return Optional.ofNullable(this.menuType);
+    }
+
+    @Override
+    public RecipeType<RECIPE> getRecipeType() {
+        return this.recipeType;
+    }
+
+    @Override
+    public boolean canHandle(MENU container, RECIPE recipe) {
+        return true;
+    }
+
+    @Override
+    public List<Slot> getRecipeSlots(MENU menu, RECIPE recipe) {
+        int inputSlotCount = this.getInputSlotCount(menu);
+        return menu.slots.subList(0, inputSlotCount);
+    }
+
+    protected int getInputSlotCount(MENU menu) {
+        return menu.getMachine().getContainerSize();
+    }
+
+    @Override
+    public List<Slot> getInventorySlots(MENU menu, RECIPE recipe) {
+        int containerSize = menu.getMachine().getContainerSize();
+        return menu.slots.subList(containerSize, containerSize + 36);
+    }
+
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/transfer/NotifyableTransferHandler.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/transfer/NotifyableTransferHandler.java
@@ -1,0 +1,52 @@
+package earth.terrarium.ad_astra.common.compat.jei.transfer;
+
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import earth.terrarium.ad_astra.common.networking.NetworkHandling;
+import earth.terrarium.ad_astra.common.networking.packet.client.NotifyRecipeTransferPacket;
+import earth.terrarium.ad_astra.common.recipe.ModRecipe;
+import earth.terrarium.ad_astra.common.screen.menu.AbstractMachineMenu;
+import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
+import mezz.jei.api.recipe.RecipeType;
+import mezz.jei.api.recipe.transfer.IRecipeTransferError;
+import mezz.jei.api.recipe.transfer.IRecipeTransferHandler;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.MenuType;
+
+public class NotifyableTransferHandler<MENU extends AbstractMachineMenu<?>, RECIPE extends ModRecipe> implements IRecipeTransferHandler<MENU, RECIPE> {
+
+    private final IRecipeTransferHandler<MENU, RECIPE> internal;
+
+    public NotifyableTransferHandler(IRecipeTransferHandler<MENU, RECIPE> internal) {
+        this.internal = internal;
+    }
+
+    @Override
+    public Class<? extends MENU> getContainerClass() {
+        return this.internal.getContainerClass();
+    }
+
+    @Override
+    public Optional<MenuType<MENU>> getMenuType() {
+        return this.internal.getMenuType();
+    }
+
+    @Override
+    public RecipeType<RECIPE> getRecipeType() {
+        return this.internal.getRecipeType();
+    }
+
+    @Override
+    public @Nullable IRecipeTransferError transferRecipe(MENU container, RECIPE recipe, IRecipeSlotsView recipeSlots, Player player, boolean maxTransfer, boolean doTransfer) {
+
+        IRecipeTransferError transferError = this.internal.transferRecipe(container, recipe, recipeSlots, player, maxTransfer, doTransfer);
+        if (transferError == null && doTransfer) {
+            NetworkHandling.CHANNEL.sendToServer(new NotifyRecipeTransferPacket(recipe.id()));
+        }
+
+        return transferError;
+    }
+
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/AdAstraReiCommonPlugin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/AdAstraReiCommonPlugin.java
@@ -1,0 +1,51 @@
+package earth.terrarium.ad_astra.common.compat.rei;
+
+import java.util.function.Function;
+
+import earth.terrarium.ad_astra.common.compat.rei.compressor.CompressorDisplay;
+import earth.terrarium.ad_astra.common.compat.rei.cryo_freezer.CryoFreezerConversionDisplay;
+import earth.terrarium.ad_astra.common.compat.rei.nasa_workbench.NasaWorkbenchDisplay;
+import earth.terrarium.ad_astra.common.recipe.CompressingRecipe;
+import earth.terrarium.ad_astra.common.recipe.CryoFuelConversionRecipe;
+import earth.terrarium.ad_astra.common.recipe.NasaWorkbenchRecipe;
+import earth.terrarium.ad_astra.common.screen.menu.AbstractMachineMenu;
+import earth.terrarium.ad_astra.common.screen.menu.CompressorMenu;
+import earth.terrarium.ad_astra.common.screen.menu.CryoFreezerMenu;
+import earth.terrarium.ad_astra.common.screen.menu.NasaWorkbenchMenu;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializerRegistry;
+import me.shedaniel.rei.api.common.plugins.REIServerPlugin;
+import me.shedaniel.rei.api.common.transfer.info.MenuInfoProvider;
+import me.shedaniel.rei.api.common.transfer.info.MenuInfoRegistry;
+import me.shedaniel.rei.api.common.transfer.info.simple.SimpleMenuInfoProvider;
+import net.minecraft.world.item.crafting.Recipe;
+
+public class AdAstraReiCommonPlugin implements REIServerPlugin {
+
+    @Override
+    public void registerDisplaySerializer(DisplaySerializerRegistry registry) {
+        registry.register(REICategories.COMPRESSOR_CATEGORY, new RecipeCodecDisplaySerializer<>(CompressorDisplay::recipe, CompressorDisplay::new, CompressingRecipe::codec));
+        registry.register(REICategories.NASA_WORKBENCH_CATEGORY, new RecipeCodecDisplaySerializer<>(NasaWorkbenchDisplay::recipe, NasaWorkbenchDisplay::new, NasaWorkbenchRecipe::codec));
+        registry.register(REICategories.CRYO_FREEZER_CONVERSION_CATEGORY, new RecipeCodecDisplaySerializer<>(CryoFreezerConversionDisplay::recipe, CryoFreezerConversionDisplay::new, CryoFuelConversionRecipe::codec));
+    }
+
+    @Override
+    public void registerMenuInfo(MenuInfoRegistry registry) {
+        registry.register(REICategories.COMPRESSOR_CATEGORY, CompressorMenu.class, this.createMachineMenuInfoProvider(CompressorDisplay::recipe));
+        registry.register(REICategories.NASA_WORKBENCH_CATEGORY, NasaWorkbenchMenu.class, this.createMenuInfoProvider(display -> new MachineMenuInfo<>(display, NasaWorkbenchDisplay::recipe) {
+            @Override
+            protected int getInputSlotCount(NasaWorkbenchMenu menu) {
+                return 14;
+            }
+        }));
+        registry.register(REICategories.CRYO_FREEZER_CONVERSION_CATEGORY, CryoFreezerMenu.class, this.createMachineMenuInfoProvider(CryoFreezerConversionDisplay::recipe));
+    }
+
+    private <MENU extends AbstractMachineMenu<?>, DISPLAY extends Display> MenuInfoProvider<MENU, DISPLAY> createMenuInfoProvider(Function<DISPLAY, MachineMenuInfo<MENU, DISPLAY>> func) {
+        return (SimpleMenuInfoProvider<MENU, DISPLAY>) func::apply;
+    }
+
+    private <MENU extends AbstractMachineMenu<?>, DISPLAY extends Display> MenuInfoProvider<MENU, DISPLAY> createMachineMenuInfoProvider(Function<DISPLAY, Recipe<?>> func) {
+        return this.createMenuInfoProvider(display -> new MachineMenuInfo<>(display, func));
+    }
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/MachineMenuInfo.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/MachineMenuInfo.java
@@ -1,0 +1,43 @@
+package earth.terrarium.ad_astra.common.compat.rei;
+
+import java.util.function.Function;
+
+import earth.terrarium.ad_astra.common.screen.menu.AbstractMachineMenu;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.transfer.info.MenuInfoContext;
+import me.shedaniel.rei.api.common.transfer.info.simple.SimplePlayerInventoryMenuInfo;
+import me.shedaniel.rei.api.common.transfer.info.stack.SlotAccessor;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.crafting.Recipe;
+
+public class MachineMenuInfo<MENU extends AbstractMachineMenu<?>, DISPLAY extends Display> implements SimplePlayerInventoryMenuInfo<MENU, DISPLAY> {
+
+    private final DISPLAY display;
+    private final Function<DISPLAY, Recipe<?>> display2RecipeFunc;
+
+    public MachineMenuInfo(DISPLAY display, Function<DISPLAY, Recipe<?>> display2RecipeFunc) {
+        this.display = display;
+        this.display2RecipeFunc = display2RecipeFunc;
+    }
+
+    @Override
+    public DISPLAY getDisplay() {
+        return this.display;
+    }
+
+    @Override
+    public void markDirty(MenuInfoContext<MENU, ? extends ServerPlayer, DISPLAY> context) {
+        SimplePlayerInventoryMenuInfo.super.markDirty(context);
+        context.getMenu().onRecipeTransfer(this.display2RecipeFunc.apply(context.getDisplay()));
+    }
+
+    @Override
+    public Iterable<SlotAccessor> getInputSlots(MenuInfoContext<MENU, ?, DISPLAY> context) {
+        int inputSlotCount = this.getInputSlotCount(context.getMenu());
+        return context.getMenu().slots.subList(0, inputSlotCount).stream().map(SlotAccessor::fromSlot).toList();
+    }
+
+    protected int getInputSlotCount(MENU menu) {
+        return menu.getMachine().getContainerSize();
+    }
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/RecipeCodecDisplaySerializer.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/RecipeCodecDisplaySerializer.java
@@ -1,0 +1,34 @@
+package earth.terrarium.ad_astra.common.compat.rei;
+
+import java.util.function.Function;
+
+import com.mojang.serialization.Codec;
+
+import earth.terrarium.ad_astra.common.recipe.ModRecipe;
+import me.shedaniel.rei.api.common.display.Display;
+import me.shedaniel.rei.api.common.display.DisplaySerializer;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.resources.ResourceLocation;
+
+public record RecipeCodecDisplaySerializer<DISPLAY extends Display, RECIPE extends ModRecipe> (Function<DISPLAY, RECIPE> display2RecipeFunc, Function<RECIPE, DISPLAY> recipe2DisplayFunc, Function<ResourceLocation, Codec<RECIPE>> codecFunc) implements DisplaySerializer<DISPLAY> {
+
+    @Override
+    public CompoundTag save(CompoundTag tag, DISPLAY display) {
+        RECIPE recipe = this.display2RecipeFunc().apply(display);
+        ResourceLocation id = recipe.getId();
+        Codec<RECIPE> codec = this.codecFunc().apply(id);
+
+        tag.putString("id", id.toString());
+        tag.put("recipe", codec.encode(recipe, NbtOps.INSTANCE, null).result().get());
+        return tag;
+    }
+
+    @Override
+    public DISPLAY read(CompoundTag tag) {
+        ResourceLocation id = new ResourceLocation(tag.getString("id"));
+        Codec<RECIPE> codec = this.codecFunc().apply(id);
+        return codec.parse(NbtOps.INSTANCE, tag.get("recipe")).result().map(this.recipe2DisplayFunc()).get();
+    }
+
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/compressor/CompressorDisplay.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/compressor/CompressorDisplay.java
@@ -6,12 +6,9 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 
 import java.util.List;
 
-@Environment(EnvType.CLIENT)
 public record CompressorDisplay(CompressingRecipe recipe) implements Display {
 
 	@Override

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/cryo_freezer/CryoFreezerConversionDisplay.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/cryo_freezer/CryoFreezerConversionDisplay.java
@@ -6,12 +6,9 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 
 import java.util.List;
 
-@Environment(EnvType.CLIENT)
 public record CryoFreezerConversionDisplay(CryoFuelConversionRecipe recipe) implements Display {
 
 	@Override

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/fuel_conversion/FuelConversionDisplay.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/fuel_conversion/FuelConversionDisplay.java
@@ -6,14 +6,11 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.Holder;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Environment(EnvType.CLIENT)
 public record FuelConversionDisplay(FuelConversionRecipe recipe) implements Display {
 
 	@Override

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/nasa_workbench/NasaWorkbenchDisplay.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/nasa_workbench/NasaWorkbenchDisplay.java
@@ -6,12 +6,9 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 
 import java.util.List;
 
-@Environment(EnvType.CLIENT)
 public record NasaWorkbenchDisplay(NasaWorkbenchRecipe recipe) implements Display {
 
 	@Override

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/oxygen_conversion/OxygenConversionDisplay.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/oxygen_conversion/OxygenConversionDisplay.java
@@ -6,14 +6,11 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.core.Holder;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Environment(EnvType.CLIENT)
 public record OxygenConversionDisplay(OxygenConversionRecipe recipe) implements Display {
 
     @Override

--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/space_station/SpaceStationCategory.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/rei/space_station/SpaceStationCategory.java
@@ -13,8 +13,6 @@ import me.shedaniel.rei.api.client.registry.display.DisplayCategory;
 import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryStacks;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.Item;
@@ -23,7 +21,6 @@ import net.minecraft.world.item.ItemStack;
 import java.util.ArrayList;
 import java.util.List;
 
-@Environment(EnvType.CLIENT)
 public class SpaceStationCategory implements DisplayCategory<SpaceStationDisplay> {
 
     public static final ResourceLocation ICON = new ResourceLocation(AdAstra.MOD_ID, "textures/gui/space_station_icon.png");

--- a/common/src/main/java/earth/terrarium/ad_astra/common/networking/NetworkHandling.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/networking/NetworkHandling.java
@@ -20,6 +20,7 @@ public class NetworkHandling {
         CHANNEL.registerPacket(NetworkDirection.CLIENT_TO_SERVER, TeleportToPlanetPacket.ID, TeleportToPlanetPacket.HANDLER, TeleportToPlanetPacket.class);
         CHANNEL.registerPacket(NetworkDirection.CLIENT_TO_SERVER, CreateSpaceStationPacket.ID, CreateSpaceStationPacket.HANDLER, CreateSpaceStationPacket.class);
         CHANNEL.registerPacket(NetworkDirection.CLIENT_TO_SERVER, FlagUrlPacket.ID, FlagUrlPacket.HANDLER, FlagUrlPacket.class);
+        CHANNEL.registerPacket(NetworkDirection.CLIENT_TO_SERVER, NotifyRecipeTransferPacket.ID, NotifyRecipeTransferPacket.HANDLER, NotifyRecipeTransferPacket.class);
 
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, StartRocketPacket.ID, StartRocketPacket.HANDLER, StartRocketPacket.class);
         CHANNEL.registerPacket(NetworkDirection.SERVER_TO_CLIENT, DatapackPlanetsPacket.ID, DatapackPlanetsPacket.HANDLER, DatapackPlanetsPacket.class);

--- a/common/src/main/java/earth/terrarium/ad_astra/common/networking/packet/client/NotifyRecipeTransferPacket.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/networking/packet/client/NotifyRecipeTransferPacket.java
@@ -1,0 +1,49 @@
+package earth.terrarium.ad_astra.common.networking.packet.client;
+
+import com.teamresourceful.resourcefullib.common.networking.base.Packet;
+import com.teamresourceful.resourcefullib.common.networking.base.PacketContext;
+import com.teamresourceful.resourcefullib.common.networking.base.PacketHandler;
+
+import earth.terrarium.ad_astra.AdAstra;
+import earth.terrarium.ad_astra.common.screen.menu.AbstractMachineMenu;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.crafting.Recipe;
+
+public record NotifyRecipeTransferPacket(ResourceLocation recipeId) implements Packet<NotifyRecipeTransferPacket> {
+
+    public static final ResourceLocation ID = new ResourceLocation(AdAstra.MOD_ID, "notify_recipe_transfer_packet");
+    public static final Handler HANDLER = new Handler();
+
+    @Override
+    public ResourceLocation getID() {
+        return ID;
+    }
+
+    @Override
+    public PacketHandler<NotifyRecipeTransferPacket> getHandler() {
+        return HANDLER;
+    }
+
+    private static class Handler implements PacketHandler<NotifyRecipeTransferPacket> {
+        @Override
+        public void encode(NotifyRecipeTransferPacket packet, FriendlyByteBuf buf) {
+            buf.writeResourceLocation(packet.recipeId());
+        }
+
+        @Override
+        public NotifyRecipeTransferPacket decode(FriendlyByteBuf buf) {
+            return new NotifyRecipeTransferPacket(buf.readResourceLocation());
+        }
+
+        @Override
+        public PacketContext handle(NotifyRecipeTransferPacket packet) {
+            return (player, level) -> {
+                if (player.containerMenu instanceof AbstractMachineMenu<?> menu) {
+                    Recipe<?> recipe = level.getRecipeManager().byKey(packet.recipeId()).get();
+                    menu.onRecipeTransfer(recipe);
+                }
+            };
+        }
+    }
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/screen/menu/AbstractMachineMenu.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/screen/menu/AbstractMachineMenu.java
@@ -10,6 +10,7 @@ import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
 import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.NotNull;
 
@@ -124,6 +125,10 @@ public abstract class AbstractMachineMenu<T extends AbstractMachineBlockEntity> 
     public void broadcastChanges() {
         super.broadcastChanges();
         syncClientScreen();
+    }
+
+    public void onRecipeTransfer(Recipe<?> recipe) {
+
     }
 
     public abstract void syncClientScreen();

--- a/common/src/main/java/earth/terrarium/ad_astra/common/screen/menu/NasaWorkbenchMenu.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/screen/menu/NasaWorkbenchMenu.java
@@ -12,6 +12,8 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ClickType;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -62,6 +64,10 @@ public class NasaWorkbenchMenu extends AbstractMachineMenu<NasaWorkbenchBlockEnt
                     public boolean mayPlace(ItemStack stack) {
                         return false;
                     }
+                    @Override
+                    public boolean mayPickup(Player player) {
+                        return false;
+                    }
                 }});
         this.updateContent();
     }
@@ -91,8 +97,20 @@ public class NasaWorkbenchMenu extends AbstractMachineMenu<NasaWorkbenchBlockEnt
         this.updateContent();
     }
 
+    @Override
+    public void onRecipeTransfer(Recipe<?> recipe) {
+        super.onRecipeTransfer(recipe);
+        if (recipe instanceof NasaWorkbenchRecipe nasaWorkbenchRecipe) {
+            this.updateContent(nasaWorkbenchRecipe);
+        }
+    }
+
     public void updateContent() {
         NasaWorkbenchRecipe recipe = NasaWorkbenchRecipe.findFirst(level, f -> f.test(this.machine));
+        this.updateContent(recipe);
+    }
+
+    public void updateContent(NasaWorkbenchRecipe recipe) {
         this.recipe = recipe;
         this.machine.setItem(14, recipe == null ? ItemStack.EMPTY : recipe.getResultItem());
         this.broadcastFullState();

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -43,6 +43,9 @@
     "rei_client": [
       "earth.terrarium.ad_astra.common.compat.rei.AdAstraReiPlugin"
     ],
+    "rei_common": [
+      "earth.terrarium.ad_astra.common.compat.rei.AdAstraReiCommonPlugin"
+    ],
     "jei_mod_plugin": [
       "earth.terrarium.ad_astra.common.compat.jei.AdAstraJeiPlugin"
     ]


### PR DESCRIPTION
## Changeds

1. Register RecipeTransferHandler in JEI
2. Register MenuInfoProvider in REI
3. Create REI common plugin
4. Create NotifyRecipeTransferPacket

## Support Machines

1. Compressor
2. NASA Workbench
3. Cryo Freezer

## About NotifyRecipeTransferPacket

NASAWorkbenchMenu was updated result item when `player click slot`.
So if update item by BlockEntity or directly by code, can't craft rocket right now. (It was should reopen menu)
Because 'updateContent' was not called. 
https://github.com/terrarium-earth/Ad-Astra/blob/fbbef9d658ab682911f07906faa2844f905b7cca/common/src/main/java/earth/terrarium/ad_astra/common/screen/menu/NasaWorkbenchMenu.java#L94

REI is support callback about 'move items'.  (In common plugin)
Call 'updateContent' in callback, it is no problem.

But JEI is not support, also client side mod.
Need call that method manually in server side.
So created packet for notify to server call 'updateConent'.





## Demo

### REI in fabric
![REI](https://user-images.githubusercontent.com/44163945/208236720-39946c6f-5dae-4cd9-8bdd-9ca271b910b6.gif)

### JEI in forge
![JEI](https://user-images.githubusercontent.com/44163945/208236727-918e008f-65c2-4c64-8bc2-80db2e51395d.gif)
