### PR TITLE
Fuel Refinery support more fluid 

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/category/FuelConversionCategory.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/compat/jei/category/FuelConversionCategory.java
@@ -9,6 +9,7 @@ import earth.terrarium.ad_astra.common.compat.jei.FluidBarDrawable;
 import earth.terrarium.ad_astra.common.config.FuelRefineryConfig;
 import earth.terrarium.ad_astra.common.recipe.FuelConversionRecipe;
 import earth.terrarium.botarium.api.fluid.FluidHooks;
+import mezz.jei.api.gui.builder.IIngredientAcceptor;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawableAnimated;
 import mezz.jei.api.gui.ingredient.IRecipeSlotsView;
@@ -41,7 +42,8 @@ public class FuelConversionCategory extends BaseCategory<FuelConversionRecipe> {
     @Override
     public void setRecipe(IRecipeLayoutBuilder builder, FuelConversionRecipe recipe, IFocusGroup focuses) {
         builder.addInvisibleIngredients(RecipeIngredientRole.CATALYST).addIngredients(Ingredient.of(ModItems.FUEL_REFINERY.get()));
-        builder.addInvisibleIngredients(RecipeIngredientRole.INPUT).addFluidStack(recipe.getFluidInput().get(0).value(), FluidHooks.buckets(1));
+        IIngredientAcceptor<?> input = builder.addInvisibleIngredients(RecipeIngredientRole.INPUT);
+        recipe.getFluidInput().stream().forEach(fluid -> input.addFluidStack(fluid.value(), FluidHooks.buckets(1)));
         builder.addInvisibleIngredients(RecipeIngredientRole.OUTPUT).addFluidStack(recipe.getFluidOutput(), FluidHooks.buckets(1));
     }
 

--- a/common/src/main/resources/data/ad_astra/tags/fluids/oil.json
+++ b/common/src/main/resources/data/ad_astra/tags/fluids/oil.json
@@ -6,6 +6,14 @@
     {
       "required": false,
       "id": "techreborn:oil"
+    },
+    {
+      "required": false,
+      "id": "modern_industrialization:crude_oil"
+    },
+    {
+      "required": false,
+      "id": "#forge:crude_oil"
     }
   ]
 }

--- a/forge/src/main/resources/data/forge/tags/fluids/crude_oil.json
+++ b/forge/src/main/resources/data/forge/tags/fluids/crude_oil.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:oil",
+    "ad_astra:flowing_oil"
+  ]
+}


### PR DESCRIPTION
## Changeds

1. Support more fluids to FuelConversionRecipe
2. Oil has 'forge:crude_oil' tag.
3. Link new supported fluids as input at FuelConversionCategory in JEI Plugin.

## Supported Fluids

### Fabric

Modern Industrialization: Crude Oil

### Forge

#forge:crude_oil Tag

