### PR TITLE
Add method that return gravity by entity

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/item/armor/JetSuit.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/item/armor/JetSuit.java
@@ -167,7 +167,7 @@ public class JetSuit extends NetheriteSpaceSuit implements EnergyItem {
         }
         isFallFlying = true;
 
-        double speed = SpaceSuitConfig.jetSuitSpeed - (ModUtils.getPlanetGravity(player.level) * 0.25);
+        double speed = SpaceSuitConfig.jetSuitSpeed - (ModUtils.getEntityGravity(player) * 0.25);
         Vec3 rotationVector = player.getLookAngle().scale(speed);
         Vec3 velocity = player.getDeltaMovement();
         player.setDeltaMovement(velocity.add(rotationVector.x() * 0.1 + (rotationVector.x() * 1.5 - velocity.x()) * 0.5, rotationVector.y() * 0.1 + (rotationVector.y() * 1.5 - velocity.y()) * 0.5, rotationVector.z() * 0.1 + (rotationVector.z() * 1.5 - velocity.z()) * 0.5));

--- a/common/src/main/java/earth/terrarium/ad_astra/common/util/ModUtils.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/util/ModUtils.java
@@ -202,6 +202,10 @@ public class ModUtils {
         return PlanetData.getPlanetFromOrbit(level.dimension()).map(Planet::level).orElse(Level.OVERWORLD);
     }
 
+    public static float getEntityGravity(Entity entity) {
+        return getPlanetGravity(entity.getLevel());
+    }
+
     /**
      * Gets the gravity of the level, in ratio to earth gravity. So a gravity of 1.0 is equivalent to earth gravity, while 0.5 would be half of earth's gravity and 2.0 would be twice the earth's gravity.
      *

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/LivingEntityMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/LivingEntityMixin.java
@@ -31,7 +31,7 @@ public abstract class LivingEntityMixin {
             }
         }
 
-        if (fallDistance <= 3 / ModUtils.getPlanetGravity(entity.level)) {
+        if (fallDistance <= 3 / ModUtils.getEntityGravity(entity)) {
             cir.setReturnValue(false);
         }
     }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/AbstractArrowMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/AbstractArrowMixin.java
@@ -23,7 +23,7 @@ public abstract class AbstractArrowMixin {
             Entity entity = (Entity) (Object) this;
             if (!entity.isNoGravity()) {
                 Vec3 velocity = entity.getDeltaMovement();
-                double newGravity = CONSTANT * ModUtils.getPlanetGravity(entity.level);
+                double newGravity = CONSTANT * ModUtils.getEntityGravity(entity);
                 entity.setDeltaMovement(velocity.x(), velocity.y() + CONSTANT - newGravity, velocity.z());
             }
         }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/BoatMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/BoatMixin.java
@@ -23,7 +23,7 @@ public abstract class BoatMixin {
             Entity entity = (Entity) (Object) this;
             if (!entity.isNoGravity()) {
                 Vec3 velocity = entity.getDeltaMovement();
-                double newGravity = CONSTANT * ModUtils.getPlanetGravity(entity.level);
+                double newGravity = CONSTANT * ModUtils.getEntityGravity(entity);
                 entity.setDeltaMovement(velocity.x(), velocity.y() - CONSTANT + newGravity, velocity.z());
             }
         }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/CommonGravityEntityMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/CommonGravityEntityMixin.java
@@ -23,7 +23,7 @@ public abstract class CommonGravityEntityMixin {
         Entity entity = (Entity) (Object) this;
         if (!entity.isNoGravity()) {
             Vec3 velocity = entity.getDeltaMovement();
-            double newGravity = CONSTANT * ModUtils.getPlanetGravity(entity.level);
+            double newGravity = CONSTANT * ModUtils.getEntityGravity(entity);
             entity.setDeltaMovement(velocity.x(), velocity.y() - CONSTANT + newGravity, velocity.z());
         }
 

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/FishingHookMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/FishingHookMixin.java
@@ -21,7 +21,7 @@ public abstract class FishingHookMixin {
         Entity entity = (Entity) (Object) this;
         if (!entity.isNoGravity()) {
             Vec3 velocity = entity.getDeltaMovement();
-            double newGravity = CONSTANT * ModUtils.getPlanetGravity(entity.level);
+            double newGravity = CONSTANT * ModUtils.getEntityGravity(entity);
             entity.setDeltaMovement(velocity.x(), velocity.y() - CONSTANT + newGravity, velocity.z());
         }
     }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/LivingEntityGravityMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/LivingEntityGravityMixin.java
@@ -26,7 +26,7 @@ public abstract class LivingEntityGravityMixin {
             Vec3 velocity = entity.getDeltaMovement();
 
             if (!entity.isNoGravity() && !entity.isInWater() && !entity.isInLava() && !entity.isFallFlying() && !entity.hasEffect(MobEffects.SLOW_FALLING)) {
-                double newGravity = CONSTANT * ModUtils.getPlanetGravity(entity.level);
+                double newGravity = CONSTANT * ModUtils.getEntityGravity(entity);
                 entity.setDeltaMovement(velocity.x(), velocity.y() + CONSTANT - newGravity, velocity.z());
             }
         }
@@ -36,6 +36,6 @@ public abstract class LivingEntityGravityMixin {
     @ModifyVariable(method = "causeFallDamage", at = @At("HEAD"), ordinal = 1, argsOnly = true)
     private float adastra_causeFallDamage(float damageMultiplier) {
         LivingEntity entity = ((LivingEntity) (Object) this);
-        return damageMultiplier * ModUtils.getPlanetGravity(entity.level);
+        return damageMultiplier * ModUtils.getEntityGravity(entity);
     }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrowableProjectileMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrowableProjectileMixin.java
@@ -14,7 +14,7 @@ public abstract class ThrowableProjectileMixin {
     @Inject(method = "getGravity", at = @At("HEAD"), cancellable = true)
     public void adastra_getGravity(CallbackInfoReturnable<Float> cir) {
         if (AdAstraConfig.doEntityGravity) {
-            cir.setReturnValue(0.03f * ModUtils.getPlanetGravity(((Entity) (Object) this).getLevel()));
+            cir.setReturnValue(0.03f * ModUtils.getEntityGravity((Entity) (Object) this));
         }
     }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrownExperienceBottleMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrownExperienceBottleMixin.java
@@ -14,7 +14,7 @@ public abstract class ThrownExperienceBottleMixin {
     @Inject(method = "getGravity", at = @At("HEAD"), cancellable = true)
     public void adastra_getGravity(CallbackInfoReturnable<Float> cir) {
         if (AdAstraConfig.doEntityGravity) {
-            cir.setReturnValue(0.07f * ModUtils.getPlanetGravity(((Entity) (Object) this).getLevel()));
+            cir.setReturnValue(0.07f * ModUtils.getEntityGravity((Entity) (Object) this));
 
         }
     }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrownPotionMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/gravity/ThrownPotionMixin.java
@@ -14,7 +14,7 @@ public abstract class ThrownPotionMixin {
     @Inject(method = "getGravity", at = @At("HEAD"), cancellable = true)
     public void adastra_getGravity(CallbackInfoReturnable<Float> cir) {
         if (AdAstraConfig.doEntityGravity) {
-            cir.setReturnValue(0.05f * ModUtils.getPlanetGravity(((Entity) (Object) this).getLevel()));
+            cir.setReturnValue(0.05f * ModUtils.getEntityGravity((Entity) (Object) this));
         }
     }
 }


### PR DESCRIPTION
## Summary

I plan add item to stabilize gravity in my addon.
But in Ad Astra code now, no common method with entity in arguments.
I want to stabilize gravity by separating each entity.

This pull request add an intermediate method that takes an Entity and calls 'ModUtils.get Planet Gravity(Level)'.
And replace calling method using entity instead of level.
I will add mixin to add my feature at that method.

And i saw this suggestion in discord.
It looks like this is also needed to implement this suggestion.
https://discord.com/channels/880995984426020885/1059550231705952366