### PR TITLE
Add doOxygen check for placing blocks

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/BlockMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/BlockMixin.java
@@ -1,6 +1,7 @@
 package earth.terrarium.ad_astra.mixin;
 
 import earth.terrarium.ad_astra.AdAstra;
+import earth.terrarium.ad_astra.common.config.AdAstraConfig;
 import earth.terrarium.ad_astra.common.util.OxygenUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Registry;
@@ -21,6 +22,9 @@ public abstract class BlockMixin {
 
     @Inject(method = "setPlacedBy", at = @At("HEAD"))
     public void adastra_setPlacedBy(Level level, BlockPos pos, BlockState state, @Nullable LivingEntity placer, ItemStack itemStack, CallbackInfo ci) {
+        if (!AdAstraConfig.doOxygen) {
+            return;
+        }
         Block block = (Block) (Object) this;
         if (block instanceof BushBlock || block instanceof CactusBlock) {
             if (!BuiltInRegistries.BLOCK.getKey(block).getNamespace().equals(AdAstra.MOD_ID)) {


### PR DESCRIPTION
When setting doOxygen to false in config leaves, vine and grass are still being destroyed. 
This PR fixes that.

I'm not sure what's happening with the branches though, would it be better to add this to 1.19.3-rework? I can cherry pick the commit and create a new PR if that'd be preferrable.