### PR TITLE
Add wood sawing/cutting recipes

### DIFF
--- a/common/src/main/resources/data/create/recipes/cutting/aeronos_caps.json
+++ b/common/src/main/resources/data/create/recipes/cutting/aeronos_caps.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "tag": "ad_astra:aeronos_caps"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 6,
+      "item": "ad_astra:aeronos_planks"
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/cutting/glacian_log.json
+++ b/common/src/main/resources/data/create/recipes/cutting/glacian_log.json
@@ -1,0 +1,28 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "ad_astra:glacian_log"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "item": "ad_astra:stripped_glacian_log"
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/cutting/stripped_glacian_log.json
+++ b/common/src/main/resources/data/create/recipes/cutting/stripped_glacian_log.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "item": "ad_astra:stripped_glacian_log"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 6,
+      "item": "ad_astra:glacian_planks"
+    }
+  ]
+}

--- a/common/src/main/resources/data/create/recipes/cutting/strophar_caps.json
+++ b/common/src/main/resources/data/create/recipes/cutting/strophar_caps.json
@@ -1,0 +1,29 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "create"
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "type": "forge:mod_loaded",
+      "modid": "create"
+    }
+  ],
+  "type": "create:cutting",
+  "ingredients": [
+    {
+      "tag": "ad_astra:strophar_caps"
+    }
+  ],
+  "processingTime": 50,
+  "results": [
+    {
+      "count": 6,
+      "item": "ad_astra:strophar_planks"
+    }
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/items/leaves.json
+++ b/common/src/main/resources/data/minecraft/tags/items/leaves.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:glacian_leaves"
+  ]
+}

--- a/fabric/src/main/resources/data/c/tags/items/mushrooms.json
+++ b/fabric/src/main/resources/data/c/tags/items/mushrooms.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:aeronos_mushroom",
+    "ad_astra:strophar_mushroom"
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/aeronos.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/aeronos.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "ad_astra:aeronos_caps"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 6,
+      "item": "ad_astra:aeronos_planks"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/glacian.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/glacian.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "ad_astra:glacian_logs"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 6,
+      "item": "ad_astra:glacian_planks"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/strophar.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/planks/strophar.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "tag": "ad_astra:strophar_caps"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 6,
+      "item": "ad_astra:strophar_planks"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/aeronos.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/aeronos.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:aeronos_planks"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 2,
+      "item": "ad_astra:aeronos_slab"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/glacian.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/glacian.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:glacian_planks"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 2,
+      "item": "ad_astra:glacian_slab"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/strophar.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/slabs/strophar.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:strophar_planks"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 2,
+      "item": "ad_astra:strophar_slab"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/stripped/glacian.json
+++ b/fabric/src/main/resources/data/modern_industrialization/recipes/cutting_machine/stripped/glacian.json
@@ -1,0 +1,31 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "modern_industrialization"
+      ]
+    }
+  ],
+  "type": "modern_industrialization:cutting_machine",
+  "duration": 100,
+  "eu": 2,
+  "fluid_inputs": [
+    {
+      "amount": 1,
+      "fluid": "modern_industrialization:lubricant"
+    }
+  ],
+  "item_inputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:glacian_log"
+    }
+  ],
+  "item_outputs": [
+    {
+      "amount": 1,
+      "item": "ad_astra:stripped_glacian_log"
+    }
+  ]
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/aeronos_planks.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/aeronos_planks.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "tag": "ad_astra:aeronos_caps"
+    }
+  ],
+  "power": 40,
+  "results": [
+    {
+      "count": 4,
+      "item": "ad_astra:aeronos_planks"
+    },
+    {
+      "count": 3,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 81000
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/aeronos_slab_from_stairs.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/aeronos_slab_from_stairs.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:aeronos_stairs"
+    }
+  ],
+  "power": 30,
+  "results": [
+    {
+      "item": "ad_astra:aeronos_slab"
+    },
+    {
+      "count": 2,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 20250
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 100
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_planks.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_planks.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "tag": "ad_astra:glacian_logs"
+    }
+  ],
+  "power": 40,
+  "results": [
+    {
+      "count": 4,
+      "item": "ad_astra:glacian_planks"
+    },
+    {
+      "count": 3,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 81000
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_pressure_plate_from_slab.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_pressure_plate_from_slab.json
@@ -1,0 +1,35 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:glacian_slab"
+    }
+  ],
+  "power": 30,
+  "results": [
+    {
+      "count": 2,
+      "item": "ad_astra:glacian_pressure_plate"
+    },
+    {
+      "count": 2,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 20250
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_slab_from_stairs.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/glacian_slab_from_stairs.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:glacian_stairs"
+    }
+  ],
+  "power": 30,
+  "results": [
+    {
+      "item": "ad_astra:glacian_slab"
+    },
+    {
+      "count": 2,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 20250
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 100
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/strophar_planks.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/strophar_planks.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "tag": "ad_astra:strophar_caps"
+    }
+  ],
+  "power": 40,
+  "results": [
+    {
+      "count": 4,
+      "item": "ad_astra:strophar_planks"
+    },
+    {
+      "count": 3,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 81000
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 200
+}

--- a/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/strophar_slab_from_stairs.json
+++ b/fabric/src/main/resources/data/techreborn/recipes/industrial_sawmill/strophar_slab_from_stairs.json
@@ -1,0 +1,34 @@
+{
+  "fabric:load_conditions": [
+    {
+      "condition": "fabric:all_mods_loaded",
+      "values": [
+        "techreborn"
+      ]
+    }
+  ],
+  "type": "techreborn:industrial_sawmill",
+  "ingredients": [
+    {
+      "count": 1,
+      "item": "ad_astra:strophar_stairs"
+    }
+  ],
+  "power": 30,
+  "results": [
+    {
+      "item": "ad_astra:strophar_slab"
+    },
+    {
+      "count": 2,
+      "item": "techreborn:saw_dust"
+    }
+  ],
+  "tank": {
+    "amount": {
+      "droplets": 20250
+    },
+    "fluid": "minecraft:water"
+  },
+  "time": 100
+}

--- a/forge/src/main/resources/data/forge/tags/items/mushrooms.json
+++ b/forge/src/main/resources/data/forge/tags/items/mushrooms.json
@@ -1,0 +1,6 @@
+{
+  "values": [
+    "ad_astra:aeronos_mushroom",
+    "ad_astra:strophar_mushroom"
+  ]
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/chest/aeronos.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/chest/aeronos.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:aeronos_chest"
+		}
+	},
+	"mainOutput": {
+		"count": 8,
+		"item": "ad_astra:aeronos_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/chest/strophar.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/chest/strophar.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:strophar_chest"
+		}
+	},
+	"mainOutput": {
+		"count": 8,
+		"item": "ad_astra:strophar_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/door/aeronos.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/door/aeronos.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:aeronos_door"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:aeronos_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/door/glacian.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/door/glacian.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:glacian_door"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:glacian_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/door/strophar.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/door/strophar.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:strophar_door"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:strophar_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/aeronos.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/aeronos.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:aeronos_fence_gate"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:aeronos_planks"
+	},
+	"secondaryChance": 1.0,
+	"secondaryOutput": {
+		"count": 4,
+		"item": "minecraft:stick"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/glacian.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/glacian.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:glacian_fence_gate"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:glacian_planks"
+	},
+	"secondaryChance": 1.0,
+	"secondaryOutput": {
+		"count": 4,
+		"item": "minecraft:stick"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/strophar.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/fence_gate/strophar.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:strophar_fence_gate"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:strophar_planks"
+	},
+	"secondaryChance": 1.0,
+	"secondaryOutput": {
+		"count": 4,
+		"item": "minecraft:stick"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/log/aeronos.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/log/aeronos.json
@@ -1,0 +1,22 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"tag": "ad_astra:aeronos_caps"
+		}
+	},
+	"mainOutput": {
+		"count": 6,
+		"item": "ad_astra:aeronos_planks"
+	},
+	"secondaryChance": 0.25,
+	"secondaryOutput": {
+		"item": "mekanism:sawdust"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/log/glacian.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/log/glacian.json
@@ -1,0 +1,22 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"tag": "ad_astra:glacian_logs"
+		}
+	},
+	"mainOutput": {
+		"count": 6,
+		"item": "ad_astra:glacian_planks"
+	},
+	"secondaryChance": 0.25,
+	"secondaryOutput": {
+		"item": "mekanism:sawdust"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/log/strophar.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/log/strophar.json
@@ -1,0 +1,22 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"tag": "ad_astra:strophar_caps"
+		}
+	},
+	"mainOutput": {
+		"count": 6,
+		"item": "ad_astra:strophar_planks"
+	},
+	"secondaryChance": 0.25,
+	"secondaryOutput": {
+		"item": "mekanism:sawdust"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/pressure_plate/glacian.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/pressure_plate/glacian.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:glacian_pressure_plate"
+		}
+	},
+	"mainOutput": {
+		"count": 2,
+		"item": "ad_astra:glacian_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/aeronos.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/aeronos.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:aeronos_trapdoor"
+		}
+	},
+	"mainOutput": {
+		"count": 3,
+		"item": "ad_astra:aeronos_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/glacian.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/glacian.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:glacian_trapdoor"
+		}
+	},
+	"mainOutput": {
+		"count": 3,
+		"item": "ad_astra:glacian_planks"
+	}
+}

--- a/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/strophar.json
+++ b/forge/src/main/resources/data/mekanism/recipes/sawing/trapdoor/strophar.json
@@ -1,0 +1,18 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "mekanism"
+		}
+	],
+	"type": "mekanism:sawing",
+	"input": {
+		"ingredient": {
+			"item": "ad_astra:strophar_trapdoor"
+		}
+	},
+	"mainOutput": {
+		"count": 3,
+		"item": "ad_astra:strophar_planks"
+	}
+}

--- a/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_aeronos_caps.json
+++ b/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_aeronos_caps.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "thermal"
+		}
+	],
+	"type": "thermal:sawmill",
+	"ingredient": {
+		"tag": "ad_astra:aeronos_caps"
+	},
+	"result": [
+		{
+			"item": "ad_astra:aeronos_planks",
+			"count": 6
+		},
+		{
+			"item": "thermal:sawdust",
+			"chance": 1.25
+		}
+	],
+	"energy": 1000
+}

--- a/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_glacian_logs.json
+++ b/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_glacian_logs.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "thermal"
+		}
+	],
+	"type": "thermal:sawmill",
+	"ingredient": {
+		"tag": "ad_astra:glacian_logs"
+	},
+	"result": [
+		{
+			"item": "ad_astra:glacian_planks",
+			"count": 6
+		},
+		{
+			"item": "thermal:sawdust",
+			"chance": 1.25
+		}
+	],
+	"energy": 1000
+}

--- a/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_strophar_caps.json
+++ b/forge/src/main/resources/data/thermal/recipes/machines/sawmill/sawmill_strophar_caps.json
@@ -1,0 +1,23 @@
+{
+	"conditions": [
+		{
+			"type": "forge:mod_loaded",
+			"modid": "thermal"
+		}
+	],
+	"type": "thermal:sawmill",
+	"ingredient": {
+		"tag": "ad_astra:strophar_caps"
+	},
+	"result": [
+		{
+			"item": "ad_astra:strophar_planks",
+			"count": 6
+		},
+		{
+			"item": "thermal:sawdust",
+			"chance": 1.25
+		}
+	],
+	"energy": 1000
+}


### PR DESCRIPTION
Requested from gisellevonbingen/Minecraft-Ad-Astra-Giselle-Addon#20

1. Add sawing/cutting recipe about glacian/aeronos/strophar.
1. And add few missing tags.

## Added Recipes

* Auxiliary outputs are skipped to write in conversation. (e.g. Saw Dusts)

### 1. Common

#### 1. Create

1. Glacian Log -> Stripped Glacian Log
1. Stripped Glacian Log -> 6x Glacian Planks
1. #ad_astra:aeronos_caps -> 6x Aeronos Planks
1. #ad_astra:strophar_caps -> 6x Strophar Planks

### 2. Forge

#### 1. Thermal Series

1. #ad_astra:glacian_logs -> 6x Glacian Planks
1. #ad_astra:aeronos_caps -> 6x Aeronos Planks
1. #ad_astra:strophar_caps -> 6x Strophar Planks

#### 1. Mekanism

1. Logs and Caps-> 6x Each Planks
1. Doors -> 2x Planks
1. Trapdoors -> 3x Planks
1. Fence gates -> 2x Planks + 4x Stick
1. Chests -> 8x Planks
1. Glacian Pressure Plate -> 2x Glacian Planks

### 3. Fabric

#### 1. Tech Reborn

1. Logs and Caps -> 4x Planks
1. Stairs -> 1x Slab
1. Glacian Slab -> 2x Glacian Pressure Plate

#### 2. Modern Industrialization

1. Logs and Caps-> 6x Each Planks
1. Planks -> 2x Slab
1. Glacian Log -> Stripped Glacian Log