### PR TITLE
Fixed Crushing Recipes to output cobbled stone variants

### DIFF
--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_calorite_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_calorite_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "minecraft:deepslate",
+      "item": "minecraft:cobbled_deepslate",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_desh_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_desh_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "minecraft:deepslate",
+      "item": "minecraft:cobbled_deepslate",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_ice_shard_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "minecraft:deepslate",
+      "item": "minecraft:cobbled_deepslate",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_ostrum_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_ostrum_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "minecraft:deepslate",
+      "item": "minecraft:cobbled_deepslate",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_ice_shard_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:glacio_stone",
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/mars_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/mars_ice_shard_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:mars_stone",
+      "item": "ad_astra:mars_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/mars_ostrum_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/mars_ostrum_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:mars_stone",
+      "item": "ad_astra:mars_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_cheese_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_cheese_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_desh_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_desh_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_ice_shard_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/venus_calorite_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/venus_calorite_ore.json
@@ -30,7 +30,7 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:venus_stone",
+      "item": "ad_astra:venus_cobblestone",
       "count": 1,
       "chance": 0.125
     }


### PR DESCRIPTION
The crushing recipes were outputting stone variants instead of cobbled stone