### PR TITLE
Add config option to disable custom first person hand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-# Neovim (nvim-jdtls) generated files
-.project
-.factorypath
-.classpath
-.settings
-
 # User-specific stuff
 .idea/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Neovim (nvim-jdtls) generated files
+.project
+.factorypath
+.classpath
+.settings
+
 # User-specific stuff
 .idea/
 

--- a/common/src/main/java/earth/terrarium/ad_astra/common/config/SpaceSuitConfig.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/config/SpaceSuitConfig.java
@@ -102,5 +102,6 @@ public final class SpaceSuitConfig {
         type = EntryType.BOOLEAN,
         translation = "text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand"
     )
+    @Comment(value = "Custom hand rendering may interfere with Shaders", translation = "text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand.tooltip")
     public static boolean renderCustomFirstPersonHand = true;
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/common/config/SpaceSuitConfig.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/config/SpaceSuitConfig.java
@@ -96,4 +96,11 @@ public final class SpaceSuitConfig {
         translation = "text.resourcefulconfig.ad_astra.option.spaceSuit.spawnJetSuitParticles"
     )
     public static boolean spawnJetSuitParticles = true;
+
+    @ConfigEntry(
+        id = "renderCustomFirstPersonHand",
+        type = EntryType.BOOLEAN,
+        translation = "text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand"
+    )
+    public static boolean renderCustomFirstPersonHand = true;
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/client/PlayerRendererMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/client/PlayerRendererMixin.java
@@ -6,6 +6,7 @@ import com.mojang.math.Vector3f;
 import earth.terrarium.ad_astra.client.renderer.armor.JetSuitModel;
 import earth.terrarium.ad_astra.client.renderer.armor.NetheriteSpaceSuitModel;
 import earth.terrarium.ad_astra.client.renderer.armor.SpaceSuitModel;
+import earth.terrarium.ad_astra.common.config.SpaceSuitConfig;
 import earth.terrarium.ad_astra.common.item.armor.JetSuit;
 import earth.terrarium.ad_astra.common.item.armor.SpaceSuit;
 import earth.terrarium.ad_astra.common.item.vehicle.VehicleItem;
@@ -31,6 +32,7 @@ public class PlayerRendererMixin {
 
     @Inject(method = "renderRightHand", at = @At("HEAD"), cancellable = true)
     public void ad_astra$renderRightHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, CallbackInfo ci) {
+        if (!SpaceSuitConfig.renderCustomFirstPersonHand) return;
         ItemStack offhandStack = player.getOffhandItem();
         if (offhandStack.getItem() instanceof VehicleItem) {
             ci.cancel();
@@ -44,6 +46,7 @@ public class PlayerRendererMixin {
 
     @Inject(method = "renderLeftHand", at = @At("HEAD"), cancellable = true)
     public void ad_astra$renderLeftHand(PoseStack poseStack, MultiBufferSource buffer, int packedLight, AbstractClientPlayer player, CallbackInfo ci) {
+        if (!SpaceSuitConfig.renderCustomFirstPersonHand) return;
         ItemStack chest = player.getItemBySlot(EquipmentSlot.CHEST);
         if (!chest.isEmpty()) {
             if (player.getItemBySlot(EquipmentSlot.CHEST).getItem() instanceof SpaceSuit) {

--- a/forge/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
+++ b/forge/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
@@ -1,2 +1,2 @@
-// 1.19.2	2023-03-18T19:15:50.340982	Languages: en_us
-36aa08635bc15f735281a42d0ca923ec906ab343 assets/ad_astra/lang/en_us.json
+// 1.19.2	2023-06-03T13:19:48.893805272	Languages: en_us
+3b467be8dd8d7cd549f19673788acdc3f14e16e6 assets/ad_astra/lang/en_us.json

--- a/forge/src/generated/resources/assets/ad_astra/lang/en_us.json
+++ b/forge/src/generated/resources/assets/ad_astra/lang/en_us.json
@@ -704,6 +704,8 @@
   "text.resourcefulconfig.ad_astra.option.spaceSuit.jetSuitUpwardsSpeed.tooltip": "The speed when idle flying up.",
   "text.resourcefulconfig.ad_astra.option.spaceSuit.netheriteSpaceSuitHasFireResistance": "Netherite Space Suit Has Fire Resistance",
   "text.resourcefulconfig.ad_astra.option.spaceSuit.netheriteSpaceSuitTankSize": "Netherite Space Suit Tank Size",
+  "text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand": "Render Custom Space Suit Hand",
+  "text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand.tooltip": "Custom hand rendering may interfere with Shaders",
   "text.resourcefulconfig.ad_astra.option.spaceSuit.spaceSuitTankSize": "Space Suit Tank Size",
   "text.resourcefulconfig.ad_astra.option.spaceSuit.spawnJetSuitParticles": "Spawn Jet Suit Particles",
   "text.resourcefulconfig.ad_astra.option.spawning": "Spawning",

--- a/forge/src/main/java/earth/terrarium/ad_astra/datagen/provider/client/ModLangProvider.java
+++ b/forge/src/main/java/earth/terrarium/ad_astra/datagen/provider/client/ModLangProvider.java
@@ -316,6 +316,8 @@ public class ModLangProvider extends LanguageProvider {
         add("text.resourcefulconfig.ad_astra.option.spaceSuit.netheriteSpaceSuitTankSize", "Netherite Space Suit Tank Size");
         add("text.resourcefulconfig.ad_astra.option.spaceSuit.spaceSuitTankSize", "Space Suit Tank Size");
         add("text.resourcefulconfig.ad_astra.option.spaceSuit.spawnJetSuitParticles", "Spawn Jet Suit Particles");
+        add("text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand", "Render Custom Space Suit Hand");
+        add("text.resourcefulconfig.ad_astra.option.spaceSuit.renderCustomFirstPersonHand.tooltip", "Custom hand rendering may interfere with Shaders");
         add("text.resourcefulconfig.ad_astra.option.vehicles", "Vehicles");
         add("text.resourcefulconfig.ad_astra.option.vehicles.fallingExplosionMultiplier", "Vehicle Falling Explosion Multiplier");
         add("text.resourcefulconfig.ad_astra.option.vehicles.fallingExplosionMultiplier.tooltip", "How powerful the explosion should be when the vehicle has fallen.");


### PR DESCRIPTION
As detailed in #299 the custom first person hand rendering may interfere with shaders. 

This PR adds a config option that disables the custom hand rendering.