### PR TITLE
Avoid dismount from vehicles mistakes

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Lander.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Lander.java
@@ -9,6 +9,7 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
@@ -105,5 +106,13 @@ public class Lander extends Vehicle {
         if (!this.level.isClientSide) {
             ModUtils.spawnForcedParticles((ServerLevel) this.getLevel(), ParticleTypes.SPIT, this.getX(), this.getY() - 0.3, this.getZ(), 3, 0.1, 0.1, 0.1, 0.001);
         }
+    }
+
+    @Override
+    public boolean cautionForDismount(Entity passenger) {
+        if (!this.isOnGround()) {
+            return true;
+        }
+        return super.cautionForDismount(passenger);
     }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Rocket.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Rocket.java
@@ -387,4 +387,12 @@ public class Rocket extends Vehicle {
             passenger.setYRot(passenger.getYRot() + rotation);
         }
     }
+
+    @Override
+    public boolean cautionForDismount(Entity passenger) {
+        if (this.isFlying()) {
+            return true;
+        }
+        return super.cautionForDismount(passenger);
+    }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Vehicle.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/vehicle/Vehicle.java
@@ -385,4 +385,8 @@ public abstract class Vehicle extends Entity implements Updatable {
     @Override
     public void update() {
     }
+    
+    public boolean cautionForDismount(Entity passenger) {
+        return false;
+    }
 }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/PlayerMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/PlayerMixin.java
@@ -3,9 +3,11 @@ package earth.terrarium.ad_astra.mixin;
 import earth.terrarium.ad_astra.common.config.SpaceSuitConfig;
 import earth.terrarium.ad_astra.common.config.VehiclesConfig;
 import earth.terrarium.ad_astra.common.entity.vehicle.Rocket;
+import earth.terrarium.ad_astra.common.entity.vehicle.Vehicle;
 import earth.terrarium.ad_astra.common.item.armor.JetSuit;
 import earth.terrarium.ad_astra.common.item.armor.NetheriteSpaceSuit;
 import earth.terrarium.ad_astra.common.util.ModKeyBindings;
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.entity.player.Player;
@@ -18,6 +20,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Player.class)
 public abstract class PlayerMixin {
+
+    private int ad_astra$shiftDownDuration = 0;
 
     @Inject(method = "hurt", at = @At("HEAD"), cancellable = true)
     public void ad_astra$damage(DamageSource source, float amount, CallbackInfoReturnable<Boolean> cir) {
@@ -37,8 +41,8 @@ public abstract class PlayerMixin {
 
     @Inject(method = "tick", at = @At("TAIL"))
     public void ad_astra$tick(CallbackInfo ci) {
+        Player player = ((Player) (Object) this);
         if (SpaceSuitConfig.enableJetSuitFlight) {
-            Player player = ((Player) (Object) this);
             if (!player.level.isClientSide && !player.isPassenger()) {
                 ItemStack chest = player.getItemBySlot(EquipmentSlot.CHEST);
                 if (chest.getItem() instanceof JetSuit jetSuit) {
@@ -54,6 +58,24 @@ public abstract class PlayerMixin {
                         }
                     }
                 }
+            }
+        }
+        if (player.isShiftKeyDown() && player.getVehicle() instanceof Vehicle vehicle && vehicle.cautionForDismount(player)) {
+            if (this.ad_astra$shiftDownDuration == 0 && !player.getLevel().isClientSide()) {
+                player.displayClientMessage(Component.translatable("message.ad_astra.vehicle.dismount_caution"), false);
+            }
+            this.ad_astra$shiftDownDuration++;
+        } else {
+            this.ad_astra$shiftDownDuration = 0;
+        }
+    }
+
+    @Inject(method = "wantsToStopRiding", at = @At("TAIL"), cancellable = true)
+    public void ad_astra$wantsToStopRiding(CallbackInfoReturnable<Boolean> ci) {
+        Player player = ((Player) (Object) this);
+        if (player.getVehicle() instanceof Vehicle vehicle && vehicle.cautionForDismount(player)) {
+            if (ci.getReturnValueZ() && this.ad_astra$shiftDownDuration < 40) {
+                ci.setReturnValue(false);
             }
         }
     }

--- a/forge/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
+++ b/forge/src/generated/resources/.cache/c622617f6fabf890a00b9275cd5f643584a8a2c8
@@ -1,2 +1,2 @@
-// 1.19.2	2023-03-18T19:15:50.340982	Languages: en_us
-36aa08635bc15f735281a42d0ca923ec906ab343 assets/ad_astra/lang/en_us.json
+// 1.19.2	2023-06-16T22:40:10.8554119	Languages: en_us
+7ec997f41fced2c4c32e0bb89c6a4af01b2a1402 assets/ad_astra/lang/en_us.json

--- a/forge/src/generated/resources/assets/ad_astra/lang/en_us.json
+++ b/forge/src/generated/resources/assets/ad_astra/lang/en_us.json
@@ -542,6 +542,7 @@
   "message.ad_astra.hold_space": "§7Hold §cSpace!",
   "message.ad_astra.no_fuel": "§cNO FUEL! §7Fill the Rocket with §cFuel§7. (§6Sneak and Right Click§7)",
   "message.ad_astra.speed": "%s m/s",
+  "message.ad_astra.vehicle.dismount_caution": "§cCAUTION! §7Very dangerous to dismount now. Keep shift down during 40 ticks to dismount.",
   "rei.category.ad_astra.space_station": "Space Station",
   "rei.text.ad_astra.amount": "Amount: %s 🪣",
   "rei.text.ad_astra.conversion_ratio": "Conversion Ratio: %s%%",

--- a/forge/src/main/java/earth/terrarium/ad_astra/datagen/provider/client/ModLangProvider.java
+++ b/forge/src/main/java/earth/terrarium/ad_astra/datagen/provider/client/ModLangProvider.java
@@ -153,6 +153,7 @@ public class ModLangProvider extends LanguageProvider {
         add("message.ad_astra.hold_space", "§7Hold §cSpace!");
         add("message.ad_astra.no_fuel", "§cNO FUEL! §7Fill the Rocket with §cFuel§7. (§6Sneak and Right Click§7)");
         add("message.ad_astra.speed", "%s m/s");
+        add("message.ad_astra.vehicle.dismount_caution", "§cCAUTION! §7Very dangerous to dismount now. Keep shift down during 40 ticks to dismount.");
         add("rei.category.ad_astra.space_station", "Space Station");
         add("rei.text.ad_astra.amount", "Amount: %s 🪣");
         add("rei.text.ad_astra.conversion_ratio", "Conversion Ratio: %s%%");


### PR DESCRIPTION
Suppress dismount immediately when below situations.
Need press dismount key while 40 ticks to dismount.
1. Rocket launching/flying
2. Lander falling
