### PR TITLE
Add smelts_to_glass tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/smelts_to_glass.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/smelts_to_glass.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:moon_sand",
+    "ad_astra:mars_sand",
+    "ad_astra:venus_sand"
+  ]
+}

--- a/common/src/main/resources/data/minecraft/tags/items/smelts_to_glass.json
+++ b/common/src/main/resources/data/minecraft/tags/items/smelts_to_glass.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "ad_astra:moon_sand",
+    "ad_astra:mars_sand",
+    "ad_astra:venus_sand"
+  ]
+}


### PR DESCRIPTION
Not used minecraft:sand, forge:sands tag after 1.20 for smelt to sand

![image](https://github.com/terrarium-earth/Ad-Astra/assets/44163945/5d586687-a59e-494b-a6fa-405a500f2ec0)
![image](https://github.com/terrarium-earth/Ad-Astra/assets/44163945/03ae8b8b-c4ea-4680-a312-92839dd41f9d)


