### PR TITLE
Fixed Bad recipes  and Added missing ones

### DIFF
--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_calorite_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_calorite_ore.json
@@ -30,6 +30,11 @@
       "chance": 0.25
     },
     {
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
       "item": "minecraft:deepslate",
       "count": 1,
       "chance": 0.125

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_desh_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_desh_ore.json
@@ -30,6 +30,11 @@
       "chance": 0.25
     },
     {
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
       "item": "minecraft:deepslate",
       "count": 1,
       "chance": 0.125

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_ice_shard_ore.json
@@ -30,6 +30,11 @@
       "chance": 0.25
     },
     {
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
       "item": "minecraft:deepslate",
       "count": 1,
       "chance": 0.125

--- a/common/src/main/resources/data/create/recipes/crushing/deepslate_ostrum_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/deepslate_ostrum_ore.json
@@ -30,6 +30,11 @@
       "chance": 0.25
     },
     {
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
       "item": "minecraft:deepslate",
       "count": 1,
       "chance": 0.125

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_coal_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_coal_ore.json
@@ -16,18 +16,18 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:glacio_coal_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:coal",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:coal",
       "count": 1,
-      "chance": 0.25
+      "chance": 0.75
     },
     {
       "item": "create:experience_nugget",
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_copper_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_copper_ore.json
@@ -16,16 +16,16 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:glacio_copper_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
-      "count": 1
+      "item": "create:crushed_raw_copper",
+      "count": 5
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "ad_astra:crushed_raw_copper",
       "count": 1,
       "chance": 0.25
     },
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_ice_shard_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:glacio_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_iron_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_iron_ore.json
@@ -16,16 +16,16 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:glacio_iron_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:raw_iron",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "ad_astra:raw_iron",
       "count": 1,
       "chance": 0.25
     },
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/glacio_lapis_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/glacio_lapis_ore.json
@@ -16,18 +16,18 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:glacio_lapis_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
-      "count": 1
+      "item": "minecraft:lapis_lazuli",
+      "count": 10
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:lapis_lazuli",
       "count": 1,
-      "chance": 0.25
+      "chance": 0.75
     },
     {
       "item": "create:experience_nugget",
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:glacio_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/mars_ostrum_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/mars_ostrum_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:mars_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:mars_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/mercury_iron_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/mercury_iron_ore.json
@@ -16,16 +16,16 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:mercury_iron_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:raw_iron",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "ad_astra:raw_iron",
       "count": 1,
       "chance": 0.25
     },
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:mercury_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_cheese_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_cheese_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_desh_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_desh_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_ice_shard_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_ice_shard_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:moon_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/moon_iron_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/moon_iron_ore.json
@@ -16,16 +16,16 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:moon_iron_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:raw_iron",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "ad_astra:raw_iron",
       "count": 1,
       "chance": 0.25
     },
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:moon_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/venus_calorite_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/venus_calorite_ore.json
@@ -30,7 +30,12 @@
       "chance": 0.25
     },
     {
-      "item": "ad_astra:venus_stone",
+      "item": "create:experience_nugget",
+      "count": 1,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:venus_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/venus_coal_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/venus_coal_ore.json
@@ -16,18 +16,18 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:venus_coal_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:coal",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:coal",
       "count": 1,
-      "chance": 0.25
+      "chance": 0.75
     },
     {
       "item": "create:experience_nugget",
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:venus_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/venus_diamond_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/venus_diamond_ore.json
@@ -16,18 +16,18 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:venus_diamond_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:diamond",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:diamond",
       "count": 1,
-      "chance": 0.25
+      "chance": 0.75
     },
     {
       "item": "create:experience_nugget",
@@ -35,7 +35,7 @@
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "ad_astra:venus_cobblestone",
       "count": 1,
       "chance": 0.125
     }

--- a/common/src/main/resources/data/create/recipes/crushing/venus_gold_ore.json
+++ b/common/src/main/resources/data/create/recipes/crushing/venus_gold_ore.json
@@ -16,26 +16,26 @@
   "type": "create:crushing",
   "ingredients": [
     {
-      "item": "ad_astra:mars_ice_shard_ore"
+      "item": "ad_astra:venus_gold_ore"
     }
   ],
   "results": [
     {
-      "item": "ad_astra:ice_shard",
+      "item": "minecraft:raw_gold",
       "count": 1
     },
     {
-      "item": "ad_astra:ice_shard",
-      "count": 1,
-      "chance": 0.25
-    },
-    {
-      "item": "create:experience_nugget",
+      "item": "minecraft:raw_gold",
       "count": 1,
       "chance": 0.75
     },
     {
-      "item": "ad_astra:mars_cobblestone",
+      "item": "create:experience_nugget",
+      "count": 2,
+      "chance": 0.75
+    },
+    {
+      "item": "ad_astra:venus_cobblestone",
       "count": 1,
       "chance": 0.125
     }


### PR DESCRIPTION
I fixed the original recipes outputting stone variants instead of cobbled & added missing recipes for the vanilla ad astra variants of ores.