### PR TITLE
Prevent natural spawning oxygen needed entities at deoxygenated level

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenStatus.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenStatus.java
@@ -1,0 +1,20 @@
+package earth.terrarium.ad_astra.common.entity.system;
+
+public enum EntityOxygenStatus {
+    /**
+     * AdAstraConfig.doOxygen is false or Entity is undead or<br>
+     * Entity has 'ad_astra:entities/lives_without_oxygen' tag or<br>
+     * Entity's level has oxygen
+     */
+    IGNORE,
+    /**
+     * Entity is equipped full set of space suit and<br>
+     * Entity should consume oxygen in equipped space suit
+     */
+    CONSUME,
+    /**
+     * Entity is not equipped space suit or No oxygen in space suit<br>
+     * Entity should take damage by suffocation
+     */
+    DAMAGE,
+}

--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenSystem.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenSystem.java
@@ -15,25 +15,6 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 
 public class EntityOxygenSystem {
-    public enum EntityOxygenStatus {
-        /**
-         * AdAstraConfig.doOxygen is false or Entity is undead or<br>
-         * Entity has 'ad_astra:entities/lives_without_oxygen' tag or<br>
-         * Entity's level has oxygen
-         */
-        IGNORE,
-        /**
-         * Entity is equipped full set of space suit and<br>
-         * Entity should consume oxygen in equipped space suit
-         */
-        CONSUME,
-        /**
-         * Entity is not equipped space suit or No oxygen in space suit<br>
-         * Entity should take damage by suffocation
-         */
-        DAMAGE,
-    }
-
     @NotNull
     public static EntityOxygenStatus getOxygenStatus(LivingEntity entity, Level level) {
         if (!AdAstraConfig.doOxygen) {

--- a/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenSystem.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/entity/system/EntityOxygenSystem.java
@@ -1,5 +1,7 @@
 package earth.terrarium.ad_astra.common.entity.system;
 
+import org.jetbrains.annotations.NotNull;
+
 import earth.terrarium.ad_astra.common.config.AdAstraConfig;
 import earth.terrarium.ad_astra.common.item.armor.SpaceSuit;
 import earth.terrarium.ad_astra.common.registry.ModDamageSource;
@@ -10,39 +12,70 @@ import earth.terrarium.botarium.api.fluid.FluidHooks;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
 
 public class EntityOxygenSystem {
-    public static void oxygenTick(LivingEntity entity, ServerLevel level) {
+    public enum EntityOxygenStatus {
+        /**
+         * AdAstraConfig.doOxygen is false or Entity is undead or<br>
+         * Entity has 'ad_astra:entities/lives_without_oxygen' tag or<br>
+         * Entity's level has oxygen
+         */
+        IGNORE,
+        /**
+         * Entity is equipped full set of space suit and<br>
+         * Entity should consume oxygen in equipped space suit
+         */
+        CONSUME,
+        /**
+         * Entity is not equipped space suit or No oxygen in space suit<br>
+         * Entity should take damage by suffocation
+         */
+        DAMAGE,
+    }
+
+    @NotNull
+    public static EntityOxygenStatus getOxygenStatus(LivingEntity entity, Level level) {
         if (!AdAstraConfig.doOxygen) {
-            return;
+            return EntityOxygenStatus.IGNORE;
         }
         if (entity.isInvertedHealAndHarm()) {
-            return;
+            return EntityOxygenStatus.IGNORE;
         }
 
         if (ModUtils.checkTag(entity, ModTags.LIVES_WITHOUT_OXYGEN)) {
-            return;
+            return EntityOxygenStatus.IGNORE;
         }
 
         if (OxygenUtils.levelHasOxygen(level) && !entity.isUnderWater()) {
-            return;
+            return EntityOxygenStatus.IGNORE;
         }
 
         boolean entityHasOxygen = OxygenUtils.entityHasOxygen(level, entity);
         boolean hasOxygenatedSpaceSuit = SpaceSuit.hasOxygenatedSpaceSuit(entity) && SpaceSuit.hasFullSet(entity);
 
         if (entityHasOxygen && hasOxygenatedSpaceSuit && entity.isUnderWater() && !entity.canBreatheUnderwater() && !entity.hasEffect(MobEffects.WATER_BREATHING)) {
-            consumeOxygen(entity);
-            return;
+            return EntityOxygenStatus.CONSUME;
         }
 
         if (!entityHasOxygen) {
             if (hasOxygenatedSpaceSuit) {
-                consumeOxygen(entity);
+                return EntityOxygenStatus.CONSUME;
             } else if (!ModUtils.armourIsOxygenated(entity)) {
-                entity.hurt(ModDamageSource.OXYGEN, AdAstraConfig.oxygenDamage);
-                entity.setAirSupply(-40);
+                return EntityOxygenStatus.DAMAGE;
             }
+        }
+
+        return EntityOxygenStatus.IGNORE;
+    }
+
+    public static void oxygenTick(LivingEntity entity, ServerLevel level) {
+        EntityOxygenStatus status = getOxygenStatus(entity, level);
+        if (status == EntityOxygenStatus.CONSUME) {
+            consumeOxygen(entity);
+        } else if (status == EntityOxygenStatus.DAMAGE) {
+            entity.hurt(ModDamageSource.OXYGEN, AdAstraConfig.oxygenDamage);
+            entity.setAirSupply(-40);
         }
     }
 

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
@@ -8,20 +8,23 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import earth.terrarium.ad_astra.common.entity.system.EntityOxygenStatus;
 import earth.terrarium.ad_astra.common.entity.system.EntityOxygenSystem;
 import earth.terrarium.ad_astra.common.util.OxygenUtils;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 
 @Mixin(Mob.class)
-public abstract class MobMixin {
+public abstract class MobMixin extends LivingEntity {
+
+    protected MobMixin(EntityType<? extends LivingEntity> entityType, Level level) {
+        super(entityType, level);
+    }
 
     @Inject(method = "checkSpawnObstruction", at = @At("HEAD"), cancellable = true)
     public void ad_astra$checkSpawnObstruction(LevelReader levelReader, CallbackInfoReturnable<Boolean> cir) {
-
         if (levelReader instanceof Level level && !OxygenUtils.levelHasOxygen(level)) {
-            Mob mob = (Mob) (Object) this;
-
-            if (EntityOxygenSystem.getOxygenStatus(mob, level) == EntityOxygenStatus.DAMAGE) {
+            if (EntityOxygenSystem.getOxygenStatus(this, level) == EntityOxygenStatus.DAMAGE) {
                 cir.setReturnValue(false);
             }
         }

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
@@ -5,8 +5,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import earth.terrarium.ad_astra.common.entity.system.EntityOxygenStatus;
 import earth.terrarium.ad_astra.common.entity.system.EntityOxygenSystem;
-import earth.terrarium.ad_astra.common.entity.system.EntityOxygenSystem.EntityOxygenStatus;
 import earth.terrarium.ad_astra.common.util.OxygenUtils;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;

--- a/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/mixin/MobMixin.java
@@ -1,0 +1,29 @@
+package earth.terrarium.ad_astra.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import earth.terrarium.ad_astra.common.entity.system.EntityOxygenSystem;
+import earth.terrarium.ad_astra.common.entity.system.EntityOxygenSystem.EntityOxygenStatus;
+import earth.terrarium.ad_astra.common.util.OxygenUtils;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelReader;
+
+@Mixin(Mob.class)
+public abstract class MobMixin {
+
+    @Inject(method = "checkSpawnObstruction", at = @At("HEAD"), cancellable = true)
+    public void ad_astra$checkSpawnObstruction(LevelReader levelReader, CallbackInfoReturnable<Boolean> cir) {
+
+        if (levelReader instanceof Level level && !OxygenUtils.levelHasOxygen(level)) {
+            Mob mob = (Mob) (Object) this;
+
+            if (EntityOxygenSystem.getOxygenStatus(mob, level) == EntityOxygenStatus.DAMAGE) {
+                cir.setReturnValue(false);
+            }
+        }
+    }
+}

--- a/common/src/main/resources/ad_astra-common.mixins.json
+++ b/common/src/main/resources/ad_astra-common.mixins.json
@@ -13,6 +13,7 @@
     "IceBlockMixin",
     "LiquidBlockMixin",
     "LivingEntityMixin",
+    "MobMixin",
     "PaintingInvoker",
     "PiglinSpecificSensorMixin",
     "PlayerMixin",


### PR DESCRIPTION
Oxygen needed entities will be spawn in oxygen provided area.
e.g.) Alex's Mobs's fly
![image](https://github.com/terrarium-earth/Ad-Astra/assets/44163945/5fd938cd-8cfa-4cd4-a8ec-921696f69c63)
