### PR TITLE
Fix Sliding Doors not properly rotating in structures

### DIFF
--- a/common/src/main/java/earth/terrarium/ad_astra/common/block/door/SlidingDoorBlock.java
+++ b/common/src/main/java/earth/terrarium/ad_astra/common/block/door/SlidingDoorBlock.java
@@ -13,9 +13,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Explosion;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.BaseEntityBlock;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -255,6 +253,16 @@ public class SlidingDoorBlock extends BaseEntityBlock {
                 door.tick();
             }
         };
+    }
+
+    @Override
+    public BlockState rotate(BlockState state, Rotation rotation) {
+        return state.setValue(FACING, rotation.rotate(state.getValue(FACING)));
+    }
+
+    @Override
+    public BlockState mirror(BlockState state, Mirror mirror) {
+        return state.rotate(mirror.getRotation(state.getValue(FACING)));
     }
 
     public BlockPos getMainPos(BlockState state, BlockPos from) {


### PR DESCRIPTION
The `SlidingDoorBlock` class was missing the `rotate` and `mirror` methods causing them to not rotate when used in structures.

The issue is described in #376. 