### PR TITLE
[1.20.1] Add new Oxygen, Gravity events

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
+++ b/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
@@ -1,5 +1,6 @@
 package earth.terrarium.adastra.api.events;
 
+import com.teamresourceful.resourcefullib.common.utils.TriState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -15,7 +16,7 @@ import java.util.Optional;
 
 public final class AdAstraEvents {
     private static final List<OxygenTickEvent> OXYGEN_TICK_LISTENERS = new ArrayList<>();
-    private static final List<EntityHasOxygenEvent> ENTITY_HAS_OXYGEN_LISTENERS = new ArrayList<>();
+    private static final List<EntityOxygenEvent> ENTITY_OXYGEN_LISTENERS = new ArrayList<>();
     private static final List<TemperatureTickEvent> TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
     private static final List<HotTemperatureTickEvent> HOT_TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
     private static final List<ColdTemperatureTickEvent> COLD_TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
@@ -48,19 +49,19 @@ public final class AdAstraEvents {
     }
 
     @FunctionalInterface
-    public interface EntityHasOxygenEvent {
-        Optional<Boolean> tick(Entity entity, boolean hasOxygen);
+    public interface EntityOxygenEvent {
+        TriState hasOxygen(Entity entity, boolean hasOxygen);
 
-        static void register(EntityHasOxygenEvent listener) {
-            ENTITY_HAS_OXYGEN_LISTENERS.add(listener);
+        static void register(EntityOxygenEvent listener) {
+            ENTITY_OXYGEN_LISTENERS.add(listener);
         }
 
         @ApiStatus.Internal
         static boolean post(Entity entity, boolean hasOxygen) {
-            for (var listener : ENTITY_HAS_OXYGEN_LISTENERS) {
-                Optional<Boolean> newHasOxygen = listener.tick(entity, hasOxygen);
-                if (newHasOxygen.isPresent()) {
-                    return newHasOxygen.get();
+            for (var listener : ENTITY_OXYGEN_LISTENERS) {
+                TriState newOxygen = listener.hasOxygen(entity, hasOxygen);
+                if (newOxygen.isDefined()) {
+                    return newOxygen.isTrue();
                 }
             }
             return hasOxygen;
@@ -134,7 +135,7 @@ public final class AdAstraEvents {
 
     @FunctionalInterface
     public interface EntityGravityEvent {
-        Optional<Float> tick(Entity entity, float gravity);
+        Optional<Float> getGravity(Entity entity, float gravity);
 
         static void register(EntityGravityEvent listener) {
             ENTITY_GRAVITY_LISTENERS.add(listener);
@@ -143,7 +144,7 @@ public final class AdAstraEvents {
         @ApiStatus.Internal
         static float post(Entity entity, float gravity) {
             for (var listener : ENTITY_GRAVITY_LISTENERS) {
-                Optional<Float> newGravity = listener.tick(entity, gravity);
+                Optional<Float> newGravity = listener.getGravity(entity, gravity);
                 if (newGravity.isPresent()) {
                     return newGravity.get();
                 }

--- a/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
+++ b/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
@@ -56,14 +56,14 @@ public final class AdAstraEvents {
         }
 
         @ApiStatus.Internal
-        static Optional<Boolean> post(Entity entity, boolean hasOxygen) {
+        static boolean post(Entity entity, boolean hasOxygen) {
             for (var listener : ENTITY_HAS_OXYGEN_LISTENERS) {
                 Optional<Boolean> newHasOxygen = listener.tick(entity, hasOxygen);
                 if (newHasOxygen.isPresent()) {
-                    return newHasOxygen;
+                    return newHasOxygen.get();
                 }
             }
-            return Optional.empty();
+            return hasOxygen;
         }
     }
 
@@ -141,14 +141,14 @@ public final class AdAstraEvents {
         }
 
         @ApiStatus.Internal
-        static Optional<Float> post(Entity entity, float gravity) {
+        static float post(Entity entity, float gravity) {
             for (var listener : ENTITY_GRAVITY_LISTENERS) {
                 Optional<Float> newGravity = listener.tick(entity, gravity);
                 if (newGravity.isPresent()) {
-                    return newGravity;
+                    return newGravity.get();
                 }
             }
-            return Optional.empty();
+            return gravity;
         }
     }
 

--- a/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
+++ b/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
@@ -2,6 +2,7 @@ package earth.terrarium.adastra.api.events;
 
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
@@ -10,12 +11,15 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class AdAstraEvents {
     private static final List<OxygenTickEvent> OXYGEN_TICK_LISTENERS = new ArrayList<>();
+    private static final List<EntityHasOxygenEvent> ENTITY_HAS_OXYGEN_LISTENERS = new ArrayList<>();
     private static final List<TemperatureTickEvent> TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
     private static final List<HotTemperatureTickEvent> HOT_TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
     private static final List<ColdTemperatureTickEvent> COLD_TEMPERATURE_TICK_LISTENERS = new ArrayList<>();
+    private static final List<EntityGravityEvent> ENTITY_GRAVITY_LISTENERS = new ArrayList<>();
     private static final List<GravityTickEvent> GRAVITY_TICK_LISTENERS = new ArrayList<>();
     private static final List<ZeroGravityTickEvent> ZERO_GRAVITY_TICK_LISTENERS = new ArrayList<>();
     private static final List<AcidRainTickEvent> ACID_RAIN_TICK_LISTENERS = new ArrayList<>();
@@ -40,6 +44,26 @@ public final class AdAstraEvents {
                 }
             }
             return true;
+        }
+    }
+
+    @FunctionalInterface
+    public interface EntityHasOxygenEvent {
+        Optional<Boolean> tick(Entity entity, boolean hasOxygen);
+
+        static void register(EntityHasOxygenEvent listener) {
+            ENTITY_HAS_OXYGEN_LISTENERS.add(listener);
+        }
+
+        @ApiStatus.Internal
+        static Optional<Boolean> post(Entity entity, boolean hasOxygen) {
+            for (var listener : ENTITY_HAS_OXYGEN_LISTENERS) {
+                Optional<Boolean> newHasOxygen = listener.tick(entity, hasOxygen);
+                if (newHasOxygen.isPresent()) {
+                    return newHasOxygen;
+                }
+            }
+            return Optional.empty();
         }
     }
 
@@ -105,6 +129,26 @@ public final class AdAstraEvents {
                 }
             }
             return true;
+        }
+    }
+
+    @FunctionalInterface
+    public interface EntityGravityEvent {
+        Optional<Float> tick(Entity entity, float gravity);
+
+        static void register(EntityGravityEvent listener) {
+            ENTITY_GRAVITY_LISTENERS.add(listener);
+        }
+
+        @ApiStatus.Internal
+        static Optional<Float> post(Entity entity, float gravity) {
+            for (var listener : ENTITY_GRAVITY_LISTENERS) {
+                Optional<Float> newGravity = listener.tick(entity, gravity);
+                if (newGravity.isPresent()) {
+                    return newGravity;
+                }
+            }
+            return Optional.empty();
         }
     }
 

--- a/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
+++ b/common/src/main/java/earth/terrarium/adastra/api/events/AdAstraEvents.java
@@ -1,6 +1,5 @@
 package earth.terrarium.adastra.api.events;
 
-import com.teamresourceful.resourcefullib.common.utils.TriState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
@@ -12,7 +11,6 @@ import org.jetbrains.annotations.ApiStatus;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 public final class AdAstraEvents {
     private static final List<OxygenTickEvent> OXYGEN_TICK_LISTENERS = new ArrayList<>();
@@ -50,7 +48,7 @@ public final class AdAstraEvents {
 
     @FunctionalInterface
     public interface EntityOxygenEvent {
-        TriState hasOxygen(Entity entity, boolean hasOxygen);
+        boolean hasOxygen(Entity entity, boolean hasOxygen);
 
         static void register(EntityOxygenEvent listener) {
             ENTITY_OXYGEN_LISTENERS.add(listener);
@@ -59,9 +57,9 @@ public final class AdAstraEvents {
         @ApiStatus.Internal
         static boolean post(Entity entity, boolean hasOxygen) {
             for (var listener : ENTITY_OXYGEN_LISTENERS) {
-                TriState newOxygen = listener.hasOxygen(entity, hasOxygen);
-                if (newOxygen.isDefined()) {
-                    return newOxygen.isTrue();
+                boolean newOxygen = listener.hasOxygen(entity, hasOxygen);
+                if (newOxygen != hasOxygen) {
+                    return newOxygen;
                 }
             }
             return hasOxygen;
@@ -135,7 +133,7 @@ public final class AdAstraEvents {
 
     @FunctionalInterface
     public interface EntityGravityEvent {
-        Optional<Float> getGravity(Entity entity, float gravity);
+        float getGravity(Entity entity, float gravity);
 
         static void register(EntityGravityEvent listener) {
             ENTITY_GRAVITY_LISTENERS.add(listener);
@@ -144,9 +142,9 @@ public final class AdAstraEvents {
         @ApiStatus.Internal
         static float post(Entity entity, float gravity) {
             for (var listener : ENTITY_GRAVITY_LISTENERS) {
-                Optional<Float> newGravity = listener.getGravity(entity, gravity);
-                if (newGravity.isPresent()) {
-                    return newGravity.get();
+                float newGravity = listener.getGravity(entity, gravity);
+                if (newGravity != gravity) {
+                    return newGravity;
                 }
             }
             return gravity;

--- a/common/src/main/java/earth/terrarium/adastra/common/systems/GravityApiImpl.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/GravityApiImpl.java
@@ -1,5 +1,6 @@
 package earth.terrarium.adastra.common.systems;
 
+import earth.terrarium.adastra.api.events.AdAstraEvents;
 import earth.terrarium.adastra.api.planets.PlanetApi;
 import earth.terrarium.adastra.api.systems.GravityApi;
 import earth.terrarium.adastra.common.constants.PlanetConstants;
@@ -39,7 +40,8 @@ public class GravityApiImpl implements GravityApi {
 
     @Override
     public float getGravity(Entity entity) {
-        return getGravity(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
+        float gravity = getGravity(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
+        return AdAstraEvents.EntityGravityEvent.post(entity, gravity).orElse(gravity);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/adastra/common/systems/GravityApiImpl.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/GravityApiImpl.java
@@ -41,7 +41,7 @@ public class GravityApiImpl implements GravityApi {
     @Override
     public float getGravity(Entity entity) {
         float gravity = getGravity(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
-        return AdAstraEvents.EntityGravityEvent.post(entity, gravity).orElse(gravity);
+        return AdAstraEvents.EntityGravityEvent.post(entity, gravity);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
@@ -1,5 +1,6 @@
 package earth.terrarium.adastra.common.systems;
 
+import earth.terrarium.adastra.api.events.AdAstraEvents;
 import earth.terrarium.adastra.api.planets.PlanetApi;
 import earth.terrarium.adastra.api.systems.OxygenApi;
 import earth.terrarium.adastra.common.handlers.PlanetHandler;
@@ -36,7 +37,8 @@ public class OxygenApiImpl implements OxygenApi {
 
     @Override
     public boolean hasOxygen(Entity entity) {
-        return hasOxygen(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
+        boolean hasOxygen = hasOxygen(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
+        return AdAstraEvents.EntityHasOxygenEvent.post(entity, hasOxygen).orElse(hasOxygen);
     }
 
     @Override
@@ -63,10 +65,10 @@ public class OxygenApiImpl implements OxygenApi {
 
     @Override
     public void entityTick(ServerLevel level, LivingEntity entity) {
-        if (this.hasOxygen(entity)) return;
         if (entity.getType().is(ModEntityTypeTags.LIVES_WITHOUT_OXYGEN)) return;
         if (entity.getType().is(ModEntityTypeTags.CAN_SURVIVE_IN_SPACE)) return;
         if (SpaceSuitItem.hasFullSet(entity) && SpaceSuitItem.hasOxygen(entity)) return;
+        if (this.hasOxygen(entity)) return;
         entity.hurt(ModDamageSources.create(level, ModDamageSources.OXYGEN), 2);
         entity.setAirSupply(-80);
     }

--- a/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
@@ -38,7 +38,7 @@ public class OxygenApiImpl implements OxygenApi {
     @Override
     public boolean hasOxygen(Entity entity) {
         boolean hasOxygen = hasOxygen(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
-        return AdAstraEvents.EntityHasOxygenEvent.post(entity, hasOxygen).orElse(hasOxygen);
+        return AdAstraEvents.EntityHasOxygenEvent.post(entity, hasOxygen);
     }
 
     @Override

--- a/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/OxygenApiImpl.java
@@ -38,7 +38,7 @@ public class OxygenApiImpl implements OxygenApi {
     @Override
     public boolean hasOxygen(Entity entity) {
         boolean hasOxygen = hasOxygen(entity.level(), BlockPos.containing(entity.getX(), entity.getEyeY(), entity.getZ()));
-        return AdAstraEvents.EntityHasOxygenEvent.post(entity, hasOxygen);
+        return AdAstraEvents.EntityOxygenEvent.post(entity, hasOxygen);
     }
 
     @Override


### PR DESCRIPTION
Sorry for my poor english skill.

At first, I expected EntityOxygenTick to be sufficient.
But after i changed to use Events, I realized that I needed to check whether entity needed oxygen and had oxygen in the event listener.
That check will be same with OxygenAPI's check.
Beause EntityOxygenTick method doing decide whether call OxygenApi.entityTick, not whether give suffocation damage to entity.
So, i had to need to add that checks in my event listener for don't use resources at no oxygen needed dimension.

In case of GravityTickEvent, to perfectly normalize gravity in addon, Ad Astra must post event at all of code that referencing gravity. (Calculating falling damage, Code referencing gravity to be added later)
So, i think can be simplest to add event at GravityAPI.getGravity(Entity).

This pull request is just an idea about make addon can be checking entity's original state and return the whether oxygen needed, and modified gravity in my think.