### PR TITLE
[1.20.1] Glacian Ram be support shear-like item in Forge

### DIFF
--- a/forge/src/main/java/earth/terrarium/adastra/mixins/forge/common/entities/GlacianRamMixin.java
+++ b/forge/src/main/java/earth/terrarium/adastra/mixins/forge/common/entities/GlacianRamMixin.java
@@ -25,13 +25,11 @@ public abstract class GlacianRamMixin extends Animal implements IForgeShearable 
 
     @Override
     public boolean isShearable(@NotNull ItemStack item, Level level, BlockPos pos) {
-        GlacianRam self = (GlacianRam) (Object) this;
-        return self.readyForShearing();
+        return ((GlacianRam) (Object) this).readyForShearing();
     }
 
     @Override
     public @NotNull List<ItemStack> onSheared(@Nullable Player player, @NotNull ItemStack item, Level level, BlockPos pos, int fortune) {
-        GlacianRam self = (GlacianRam) (Object) this;
-        return self.onSheared(player, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
+        return ((GlacianRam) (Object) this).onSheared(player, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
     }
 }

--- a/forge/src/main/java/earth/terrarium/adastra/mixins/forge/common/entities/GlacianRamMixin.java
+++ b/forge/src/main/java/earth/terrarium/adastra/mixins/forge/common/entities/GlacianRamMixin.java
@@ -1,0 +1,37 @@
+package earth.terrarium.adastra.mixins.forge.common.entities;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+
+import earth.terrarium.adastra.common.entities.mob.GlacianRam;
+import net.minecraft.core.BlockPos;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.animal.Animal;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.IForgeShearable;
+
+@Mixin(GlacianRam.class)
+public abstract class GlacianRamMixin extends Animal implements IForgeShearable {
+
+    protected GlacianRamMixin(EntityType<? extends GlacianRam> entityType, Level level) {
+        super(entityType, level);
+    }
+
+    @Override
+    public boolean isShearable(@NotNull ItemStack item, Level level, BlockPos pos) {
+        GlacianRam self = (GlacianRam) (Object) this;
+        return self.readyForShearing();
+    }
+
+    @Override
+    public @NotNull List<ItemStack> onSheared(@Nullable Player player, @NotNull ItemStack item, Level level, BlockPos pos, int fortune) {
+        GlacianRam self = (GlacianRam) (Object) this;
+        return self.onSheared(player, player == null ? SoundSource.BLOCKS : SoundSource.PLAYERS);
+    }
+}

--- a/forge/src/main/resources/adastra.mixins.json
+++ b/forge/src/main/resources/adastra.mixins.json
@@ -6,6 +6,7 @@
     "mixins": [
         "common.CustomDyeableArmorItemMixin",
         "common.RenderedItemMixin",
+        "common.entities.GlacianRamMixin",
         "common.multipart.LevelMixin"
     ],
     "client": [


### PR DESCRIPTION
Shear-like item be can shear Glacian Ram in Forge. (e.g. Meka-Tool), same with #64.