### PR TITLE
fix: remove REI compat layer for CompressingDisplay

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,8 +127,6 @@ subprojects {
 //            "modLocalRuntime"(group = "vazkii.patchouli", name = "Patchouli", version = "$minecraftVersion-$patchouliVersion-${modLoader.uppercase()}")
 //            "modLocalRuntime"(group = "com.lowdragmc.shimmer", name = "Shimmer-$modLoader", version = "$minecraftVersion-$shimmerVersion") { isTransitive = false }
         }
-
-        "modCompileOnly"(group = "me.shedaniel", name = "REIPluginCompatibilities-forge-annotations", version = "8.+")
     }
 
     java {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -127,6 +127,8 @@ subprojects {
 //            "modLocalRuntime"(group = "vazkii.patchouli", name = "Patchouli", version = "$minecraftVersion-$patchouliVersion-${modLoader.uppercase()}")
 //            "modLocalRuntime"(group = "com.lowdragmc.shimmer", name = "Shimmer-$modLoader", version = "$minecraftVersion-$shimmerVersion") { isTransitive = false }
         }
+
+        "modCompileOnly"(group = "me.shedaniel", name = "REIPluginCompatibilities-forge-annotations", version = "8.+")
     }
 
     java {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,4 +5,5 @@ architectury {
 
 dependencies {
     modCompileOnly(group = "tech.thatgravyboat", name = "commonats", version = "2.0")
+    compileOnly(group = "me.shedaniel", name = "REIPluginCompatibilities-forge-annotations", version = "8.+")
 }

--- a/common/src/main/java/earth/terrarium/adastra/common/compat/rei/displays/CompressingDisplay.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/compat/rei/displays/CompressingDisplay.java
@@ -10,6 +10,7 @@ import net.minecraft.world.item.crafting.RecipeHolder;
 
 import java.util.List;
 
+@REIPluginCompatIgnore
 public record CompressingDisplay(CompressingRecipe recipe) implements Display {
     public CompressingDisplay(RecipeHolder<CompressingRecipe> recipe) {
         this(recipe.value());

--- a/common/src/main/java/earth/terrarium/adastra/common/compat/rei/displays/CompressingDisplay.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/compat/rei/displays/CompressingDisplay.java
@@ -6,6 +6,7 @@ import me.shedaniel.rei.api.common.category.CategoryIdentifier;
 import me.shedaniel.rei.api.common.display.Display;
 import me.shedaniel.rei.api.common.entry.EntryIngredient;
 import me.shedaniel.rei.api.common.util.EntryIngredients;
+import me.shedaniel.rei.plugincompatibilities.api.REIPluginCompatIgnore;
 import net.minecraft.world.item.crafting.RecipeHolder;
 
 import java.util.List;


### PR DESCRIPTION
# What was done
Removed REI compatibility layer from affecting CompactingDisplay, as that was causing crashes.
Refer to https://github.com/shedaniel/REIPluginCompatibilities-Issues/issues/23#issuecomment-1332489186

I do not have experience with Minecraft modding, so unsure if this is the correct way to go about it
If incorrect, please do check. Have been waiting for this fix for a couple of weeks now.

Issue #499.

# Why is this change needed
Crashes are bad.