### PR TITLE
Fixed crash with REI and REIPluginCompatibilities

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -5,4 +5,5 @@ architectury {
 
 dependencies {
     modCompileOnly(group = "tech.thatgravyboat", name = "commonats", version = "2.0")
+    compileOnly(group = "me.shedaniel", name = "REIPluginCompatibilities-forge-annotations", version = "12.0.93")
 }

--- a/common/src/main/java/earth/terrarium/adastra/common/compat/jei/AdAstraJeiPlugin.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/compat/jei/AdAstraJeiPlugin.java
@@ -6,6 +6,7 @@ import earth.terrarium.adastra.common.compat.jei.categories.*;
 import earth.terrarium.adastra.common.registry.ModCreativeTab;
 import earth.terrarium.adastra.common.registry.ModItems;
 import earth.terrarium.adastra.common.registry.ModRecipeTypes;
+import me.shedaniel.rei.plugincompatibilities.api.REIPluginCompatIgnore;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
 import mezz.jei.api.helpers.IGuiHelper;
@@ -18,6 +19,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Objects;
 
 @JeiPlugin
+@REIPluginCompatIgnore
 public class AdAstraJeiPlugin implements IModPlugin {
     @Override
     public @NotNull ResourceLocation getPluginUid() {


### PR DESCRIPTION
Fixed the issue #490. If in the 1.20.x branch you have the same problem also if you already fixed it in the #521 pull request, you should discard the #521 pull request and make these changes instead (from what i've read, the @REIPluginCompatIgnore is needed in classes that uses the @JeiPlugin annotation)