### PR TITLE
Add common cheese tags

### DIFF
--- a/common/src/main/resources/data/c/tags/items/cheese.json
+++ b/common/src/main/resources/data/c/tags/items/cheese.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ad_astra:cheese"
+  ]
+}

--- a/common/src/main/resources/data/c/tags/items/cheeses.json
+++ b/common/src/main/resources/data/c/tags/items/cheeses.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ad_astra:cheese"
+  ]
+}

--- a/common/src/main/resources/data/forge/tags/items/cheese.json
+++ b/common/src/main/resources/data/forge/tags/items/cheese.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "ad_astra:cheese"
+  ]
+}


### PR DESCRIPTION
Adding Common Cheese tags that used to exist for 1.19.2 to enable use with food mods that recognize these tags.

Accompanying feature request: #565 