### PR TITLE
Add Aeronos Transparency in AdAstraClient.java

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/client/AdAstraClient.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/AdAstraClient.java
@@ -176,6 +176,7 @@ public class AdAstraClient {
         ClientHooks.setRenderLayer(ModBlocks.AERONOS_LADDER.get(), RenderType.cutout());
         ClientHooks.setRenderLayer(ModBlocks.STROPHAR_LADDER.get(), RenderType.cutout());
         ClientHooks.setRenderLayer(ModBlocks.GLACIAN_TRAPDOOR.get(), RenderType.cutout());
+        ClientHooks.setRenderLayer(ModBlocks.AERONOS_TRAPDOOR.get(), RenderType.cutout());
     }
 
     public static void onRegisterParticles(BiConsumer<ParticleType<SimpleParticleType>, ClientPlatformUtils.SpriteParticleRegistration<SimpleParticleType>> consumer) {


### PR DESCRIPTION
Aeronos trapdoors have a really odd look in game due to their transparency not being set. This fixes the transparency issue.