### PR TITLE
[Typo]Fix a little bug for chinese translate.

### DIFF
--- a/common/src/main/resources/assets/ad_astra/lang/zh_cn.json
+++ b/common/src/main/resources/assets/ad_astra/lang/zh_cn.json
@@ -276,7 +276,7 @@
   "block.ad_astra.oil": "石油",
   "block.ad_astra.orange_flag": "橙色旗帜",
   "block.ad_astra.orange_industrial_lamp": "橙色工业台灯",
-  "block.ad_astra.ostrum_block": "紫金矿",
+  "block.ad_astra.ostrum_block": "紫金块",
   "block.ad_astra.ostrum_factory_block": "紫金工业方块",
   "block.ad_astra.ostrum_fluid_pipe": "紫金流体管道",
   "block.ad_astra.ostrum_panel": "紫金板材",


### PR DESCRIPTION
A tiny typo fix.`block` is `块` in chinese and `矿` is for ore.