### PR TITLE
Update SolarPanelBlockEntity.java

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/SolarPanelBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/SolarPanelBlockEntity.java
@@ -59,13 +59,33 @@ public class SolarPanelBlockEntity extends EnergyContainerMachineBlockEntity {
         return ChargeSlotType.POWER_ITEM;
     }
 
+
+    //// cemerson 20250105 | temp patch for solar panels not working in space at night 
+    //// Unsure if this 
+    //// OLD VERSION 
+    // @Override
+    // public void serverTick(ServerLevel level, long time, BlockState state, BlockPos pos) {
+    //     if (canFunction()) {
+    //         distributeToChargeSlots();
+    //         if (isDay()) generateEnergy(PlanetApi.API.getSolarPower(level));
+    //     }
+    // }
+    //// TEMP NEW VERSION (?)
+    private boolean isSpace = false;
+    private ServerLevel cachedSolarPanelsLevel = null;    
     @Override
     public void serverTick(ServerLevel level, long time, BlockState state, BlockPos pos) {
         if (canFunction()) {
-            distributeToChargeSlots();
-            if (isDay()) generateEnergy(PlanetApi.API.getSolarPower(level));
+            distributeToChargeSlots();            
+            if(cachedSolarPanelsLevel == null){                
+                cachedSolarPanelsLevel = level;
+                isSpace = PlanetApi.API.isSpace(cachedSolarPanelsLevel);                                    
+            }                        
+            if (isDay() || isSpace) {
+                generateEnergy(PlanetApi.API.getSolarPower(level));
+            }                                    
         }
-    }
+    }    
 
     @Override
     public void tickSideInteractions(BlockPos pos, Predicate<Direction> filter, List<ConfigurationEntry> sideConfig) {


### PR DESCRIPTION
Temp fix for solar panels not working in space at night. Initial tests seem to show it working (planets still obey night time rule for no solar power, but space solar panels chug all the time - unsure if there is "dark side of planet" logic to work with or not). Realize it's very possible there's a more appropriate/cleaner place to put this fix so no offense if you need to reject this pull request and handle differently ... I just couldn't wait and wanted to play with it now vs later :) 