### PR TITLE
fix: Missing rain sounds

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,1 @@
-- fixed guidebook not opening #256
-- fixed broken guis of some of the machine screens due to changed textures
-- allow tech reborn and modern industrialization oil to be used in the fuel refinery #258
-- fixed "Secrets Beneath" achievement #257
+- fixed rain sounds not being produced in overworld (#628)

--- a/src/main/java/com/github/alexnijjar/ad_astra/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/com/github/alexnijjar/ad_astra/mixin/client/WorldRendererMixin.java
@@ -64,18 +64,22 @@ public abstract class WorldRendererMixin {
 	// Venus rain.
 	@Inject(method = "tickRainSplashing", at = @At("HEAD"), cancellable = true)
 	public void adastra_tickRainSplashing(Camera camera, CallbackInfo info) {
-		if(!ModUtils.isPlanet(this.client.world)) {
-			info.cancel();
-		}
-		WorldRendererAccessor worldRenderer = (WorldRendererAccessor) (Object) this;
-
-
-
 		MinecraftClient client = MinecraftClient.getInstance();
 		RegistryKey<World> world = client.world.getRegistryKey();
+		boolean isVenus = false;
 		for (SkyRenderer skyRenderer : AdAstraClient.skyRenderers) {
 			if (world.equals(skyRenderer.dimension()) && skyRenderer.weatherEffects().equals(WeatherEffects.VENUS)) {
-
+				isVenus = true;
+				break;
+			}
+		}
+		
+		if (!isVenus) {
+			return;
+		}		
+		
+				WorldRendererAccessor worldRenderer = (WorldRendererAccessor) (Object) this;
+	
 				float f = client.world.getRainGradient(1.0f) / (MinecraftClient.isFancyGraphicsOrBetter() ? 1.0f : 2.0f);
 				if (f <= 0.0f) {
 					return;
@@ -115,10 +119,6 @@ public abstract class WorldRendererMixin {
 						client.world.playSound((BlockPos) blockPos2, SoundEvents.WEATHER_RAIN, SoundCategory.WEATHER, 0.2f, 1.0f, false);
 					}
 				}
-				info.cancel();
-				break;
-			}
-		}
-		return;
+		info.cancel();
 	}
 }


### PR DESCRIPTION
Fixes bug #628 (no rain particles) - restoring rain sounds in the overworld, while retaining custom effects when player is on Venus. 

Slightly changed test for detecting if player is on Venus (skips new code if player is elsewhere, to allow rain particles in other world dimensions to render again, resulting in rain sounds being played as normal)

(My first ever Github contribution! Apologies, I know the 1.18.2 branch is old, but wanted to assist Create: Astral modpack users)

