### PR TITLE
Fixed non-temperate planets never extinguishing "lit" blocks

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/common/systems/EnvironmentEffects.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/systems/EnvironmentEffects.java
@@ -51,7 +51,9 @@ public class EnvironmentEffects {
                         tickHot(level, pos, state);
                     } else if (temperature < PlanetConstants.FREEZE_TEMPERATURE) {
                         tickCold(level, pos, state);
-                    } else if (!OxygenApi.API.hasOxygen(level, pos)) {
+                    }
+                    
+                    if (!OxygenApi.API.hasOxygen(level, pos)) {
                         tickBlock(level, pos, state);
                     }
                 }


### PR DESCRIPTION
If a planet is considered "hot" or "cold", it only ever runs that respective `tick` method in EnvironmentEffects, meaning `tickBlock` is never called unless you're on a "livable" temperature planet with no oxygen.

Presently, a campfire always stays lit on the moon, for example.