### PR TITLE
Fix excess gas being voided in oxygen loader

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenDistributorBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenDistributorBlockEntity.java
@@ -78,7 +78,6 @@ public class OxygenDistributorBlockEntity extends OxygenLoaderBlockEntity {
         energyPerTick = tag.getLong("EnergyPerTick");
         fluidPerTick = tag.getFloat("FluidPerTick");
         distributedBlocksCount = tag.getInt("DistributedBlocksCount");
-        accumulatedFluid = tag.getDouble("AccumulatedFluid");
         limit = tag.getInt("Limit");
     }
 
@@ -88,7 +87,6 @@ public class OxygenDistributorBlockEntity extends OxygenLoaderBlockEntity {
         tag.putLong("EnergyPerTick", energyPerTick);
         tag.putFloat("FluidPerTick", fluidPerTick);
         tag.putInt("DistributedBlocksCount", distributedBlocksCount);
-        tag.putDouble("AccumulatedFluid", accumulatedFluid);
         tag.putInt("Limit", limit);
     }
 
@@ -118,12 +116,8 @@ public class OxygenDistributorBlockEntity extends OxygenLoaderBlockEntity {
         if (canFunction() && canDistribute) {
             getEnergyStorage().internalExtract(calculateEnergyPerTick(), false);
             setLit(true);
-            accumulatedFluid += fluidPerTick;
-            int wholeBuckets = (int) (accumulatedFluid / 1000f);
-            if (wholeBuckets > 0) {
-                consumeDistribution(FluidConstants.fromMillibuckets(Math.max(1, wholeBuckets / 1000)));
-                accumulatedFluid -= wholeBuckets;
-            }
+
+            consumeDistribution(FluidConstants.fromMillibuckets(Math.max(1, fluidPerTick)));
 
             if (time % MachineConfig.distributionRefreshRate == 0) tickOxygen(level, pos, state);
 

--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
@@ -24,8 +24,6 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.block.state.BlockState;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -40,7 +38,6 @@ public class OxygenLoaderBlockEntity extends RecipeMachineBlockEntity<OxygenLoad
         new ConfigurationEntry(ConfigurationType.FLUID, Configuration.NONE, ConstantComponents.SIDE_CONFIG_INPUT_FLUID),
         new ConfigurationEntry(ConfigurationType.FLUID, Configuration.NONE, ConstantComponents.SIDE_CONFIG_OUTPUT_FLUID)
     );
-    private static final Logger log = LogManager.getLogger(OxygenLoaderBlockEntity.class);
 
     private WrappedBlockFluidContainer fluidContainer;
 

--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
@@ -24,6 +24,8 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.level.block.state.BlockState;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -38,6 +40,7 @@ public class OxygenLoaderBlockEntity extends RecipeMachineBlockEntity<OxygenLoad
         new ConfigurationEntry(ConfigurationType.FLUID, Configuration.NONE, ConstantComponents.SIDE_CONFIG_INPUT_FLUID),
         new ConfigurationEntry(ConfigurationType.FLUID, Configuration.NONE, ConstantComponents.SIDE_CONFIG_OUTPUT_FLUID)
     );
+    private static final Logger log = LogManager.getLogger(OxygenLoaderBlockEntity.class);
 
     private WrappedBlockFluidContainer fluidContainer;
 
@@ -93,7 +96,7 @@ public class OxygenLoaderBlockEntity extends RecipeMachineBlockEntity<OxygenLoad
     public void recipeTick(ServerLevel level, WrappedBlockEnergyContainer energyStorage) {
         if (recipe == null) return;
         if (fluidContainer == null) getFluidContainer();
-        if (!canCraft()) {
+        if (!canCraft() || recipe.result().getFluidAmount() != fluidContainer.internalInsert(recipe.result(), true)) {
             clearRecipe();
             return;
         }


### PR DESCRIPTION
Prevents oxygen loader from running conversion recipe unless the output tank can entirely hold it. Prevents the excess gas from being voided.
Also fixes the same issue for the oxygen distributor because they share this code

Fix for https://github.com/terrarium-earth/Ad-Astra/issues/544