### PR TITLE
WIP: initial Minecraft 1.21.1 + NeoForge migration scaffold

### DIFF
--- a/MIGRATION_1.21.1_NEOFORGE.md
+++ b/MIGRATION_1.21.1_NEOFORGE.md
@@ -1,0 +1,46 @@
+# Ad Astra 1.21.1 + NeoForge migration (initial pass)
+
+## Baseline selected
+- Upstream branch: `1.20.x` (default and newest maintained line in upstream repo)
+- Working branch: `port/1.21.1-neoforge-initial`
+- Reference jar inspected: `/home/openclaw/.openclaw/media/inbound/a2d91126-d2e3-4e2e-9fce-aec678e3ee6a`
+  - Jar metadata indicates it is a NeoForge/FML build targeting **1.20.4-era** dependencies, useful as parity confirmation only.
+
+## Changes in this initial port attempt
+- Bumped root `minecraftVersion` to `1.21.1`.
+- Bumped NeoForge loader dependency to `21.1.226`.
+- Updated NeoForge mod dependency ranges in `neoforge.mods.toml`:
+  - `neoforge`: `[21.1,)`
+  - `minecraft`: `[1.21.1,)`
+- Removed hardcoded Minecraft version from parchment mapping artifact id:
+  - `parchment-1.20.6` -> `parchment-$minecraftVersion`
+- Replaced hardcoded lib artifact suffixes with `$minecraftVersion` for:
+  - `resourcefullib`
+  - `resourcefulconfig`
+  - `botarium`
+  - `athena`
+
+## Build / verification status
+- Could not run Gradle compilation in this environment: Java runtime is missing.
+- Command attempted:
+  - `./gradlew :neoforge:tasks`
+  - `./gradlew :neoforge:compileJava -x test`
+- Failure:
+  - `ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.`
+
+## Remaining blockers / checklist
+- [ ] Install JDK 21 and set `JAVA_HOME`.
+- [ ] Resolve dependency availability for 1.21.1 artifacts:
+  - ResourcefulLib
+  - ResourcefulConfig
+  - Botarium
+  - Athena
+  - REI/JEI compileOnly versions
+- [ ] Validate parchment mapping availability for `parchment-1.21.1` (or switch to Mojang-only mappings if unavailable).
+- [ ] Run `:common:compileJava` and `:neoforge:compileJava` and fix API breakages from 1.20.6 -> 1.21.1.
+- [ ] Run data generation (`:neoforge:runData`) and inspect generated resources changes.
+- [ ] Smoke test in NeoForge dev client/server runs.
+- [ ] Review/adjust mixins and access changes for 1.21.1 internals.
+
+## Notes
+This is an initial migration scaffold commit to unblock iterative compile-fix cycles once Java + dependency resolution are available.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,22 +93,22 @@ subprojects {
 
             officialMojangMappings()
 
-            parchment(create(group = "org.parchmentmc.data", name = "parchment-1.20.6", version = parchmentVersion))
+            parchment(create(group = "org.parchmentmc.data", name = "parchment-$minecraftVersion", version = parchmentVersion))
         })
 
         "modApi"(
             group = "com.teamresourceful.resourcefullib",
-            name = "resourcefullib-$modLoader-1.20.5",
+            name = "resourcefullib-$modLoader-$minecraftVersion",
             version = resourcefulLibVersion
         )
         "modApi"(
             group = "com.teamresourceful.resourcefulconfig",
-            name = "resourcefulconfig-$modLoader-1.20.5",
+            name = "resourcefulconfig-$modLoader-$minecraftVersion",
             version = resourcefulConfigVersion
         )
         "modApi"(
             group = "earth.terrarium.botarium",
-            name = "botarium-$modLoader-1.20.4",
+            name = "botarium-$modLoader-$minecraftVersion",
             version = botariumVersion
         )
         if (isCommon) {
@@ -149,7 +149,7 @@ subprojects {
 
             "modLocalRuntime"(
                 group = "earth.terrarium.athena",
-                name = "athena-$modLoader-1.20.5",
+                name = "athena-$modLoader-$minecraftVersion",
                 version = athenaVersion
             )
             "modCompileOnly"(group = "me.shedaniel", name = "RoughlyEnoughItems-api-$modLoader", version = reiVersion)

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ enabledPlatforms=fabric,neoforge
 version=1.16.6
 group=earth.terrarium.adastra
 
-minecraftVersion=1.20.6
+minecraftVersion=1.21.1
 mixinExtrasVersion=0.3.2
 parchmentVersion=2024.05.01
 

--- a/neoforge/gradle.properties
+++ b/neoforge/gradle.properties
@@ -1,2 +1,2 @@
 loom.platform=neoforge
-neoforgeVersion=20.6.98-beta
+neoforgeVersion=21.1.226

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -22,14 +22,14 @@ config = "adastra-common.mixins.json"
 [[dependencies.ad_astra]]
 modId = "neoforge"
 type="required"
-versionRange = "[20.6,)"
+versionRange = "[21.1,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.ad_astra]]
 modId = "minecraft"
 type="required"
-versionRange = "[1.20.6,)"
+versionRange = "[1.21.1,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
# Ad Astra 1.21.1 + NeoForge migration (initial pass)

## Baseline selected
- Upstream branch: `1.20.x` (default and newest maintained line in upstream repo)
- Working branch: `port/1.21.1-neoforge-initial`
- Reference jar inspected: `/home/openclaw/.openclaw/media/inbound/a2d91126-d2e3-4e2e-9fce-aec678e3ee6a`
  - Jar metadata indicates it is a NeoForge/FML build targeting **1.20.4-era** dependencies, useful as parity confirmation only.

## Changes in this initial port attempt
- Bumped root `minecraftVersion` to `1.21.1`.
- Bumped NeoForge loader dependency to `21.1.226`.
- Updated NeoForge mod dependency ranges in `neoforge.mods.toml`:
  - `neoforge`: `[21.1,)`
  - `minecraft`: `[1.21.1,)`
- Removed hardcoded Minecraft version from parchment mapping artifact id:
  - `parchment-1.20.6` -> `parchment-$minecraftVersion`
- Replaced hardcoded lib artifact suffixes with `$minecraftVersion` for:
  - `resourcefullib`
  - `resourcefulconfig`
  - `botarium`
  - `athena`

## Build / verification status
- Could not run Gradle compilation in this environment: Java runtime is missing.
- Command attempted:
  - `./gradlew :neoforge:tasks`
  - `./gradlew :neoforge:compileJava -x test`
- Failure:
  - `ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.`

## Remaining blockers / checklist
- [ ] Install JDK 21 and set `JAVA_HOME`.
- [ ] Resolve dependency availability for 1.21.1 artifacts:
  - ResourcefulLib
  - ResourcefulConfig
  - Botarium
  - Athena
  - REI/JEI compileOnly versions
- [ ] Validate parchment mapping availability for `parchment-1.21.1` (or switch to Mojang-only mappings if unavailable).
- [ ] Run `:common:compileJava` and `:neoforge:compileJava` and fix API breakages from 1.20.6 -> 1.21.1.
- [ ] Run data generation (`:neoforge:runData`) and inspect generated resources changes.
- [ ] Smoke test in NeoForge dev client/server runs.
- [ ] Review/adjust mixins and access changes for 1.21.1 internals.

## Notes
This is an initial migration scaffold commit to unblock iterative compile-fix cycles once Java + dependency resolution are available.
