### PR TITLE
Change BasicContainer to not call update on container changes

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/base/BasicContainer.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/base/BasicContainer.java
@@ -19,15 +19,12 @@ public interface BasicContainer extends Container {
 
     @Override
     default @NotNull ItemStack removeItem(int slot, int amount) {
-        ItemStack stack = ContainerHelper.removeItem(items(), slot, amount);
-        update();
-        return stack;
+        return ContainerHelper.removeItem(items(), slot, amount);
     }
 
     @Override
     default void setItem(int slot, @NotNull ItemStack stack) {
         items().set(slot, stack);
-        update();
     }
 
     @Override
@@ -48,6 +45,5 @@ public interface BasicContainer extends Container {
     @Override
     default void clearContent() {
         items().clear();
-        update();
     }
 }


### PR DESCRIPTION
Due to BasicContainer calling update, it can trigger a new Fabric Transaction while another one is pending.
Container changes should not perform Transactions (they shoud occur on a server Tick)
Fixes terrarium-earth/ad-astra#549
