### PR TITLE
Fluid containers filter fix

### DIFF
--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/FuelRefineryBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/FuelRefineryBlockEntity.java
@@ -69,7 +69,7 @@ public class FuelRefineryBlockEntity extends RecipeMachineBlockEntity<RefiningRe
                 1,
                 (tank, holder) -> level().getRecipeManager().getAllRecipesFor(ModRecipeTypes.REFINING.get())
                     .stream()
-                    .anyMatch(r -> r.input().test(holder)),
+                    .anyMatch(r -> r.input().getIngredient().test(holder)),
                 (tank, holder) -> level().getRecipeManager().getAllRecipesFor(ModRecipeTypes.REFINING.get())
                     .stream()
                     .anyMatch(r -> r.result().matches(holder))));

--- a/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/blockentities/machines/OxygenLoaderBlockEntity.java
@@ -73,7 +73,7 @@ public class OxygenLoaderBlockEntity extends RecipeMachineBlockEntity<OxygenLoad
                 1,
                 (tank, holder) -> level().getRecipeManager().getAllRecipesFor(ModRecipeTypes.OXYGEN_LOADING.get())
                     .stream()
-                    .anyMatch(r -> r.input().test(holder)),
+                    .anyMatch(r -> r.input().getIngredient().test(holder)),
                 (tank, holder) -> level().getRecipeManager().getAllRecipesFor(ModRecipeTypes.OXYGEN_LOADING.get())
                     .stream()
                     .anyMatch(r -> r.result().matches(holder))));


### PR DESCRIPTION
Fixing an issue with FluidContainers in OxygenLoader and FuelRefinery where create pipes only worked if pressure was high enough.
Root cause of the issue was that QuantifiedFluidIngredient checks also fluid amount, while only the type is important.