### PR TITLE
Change Flag URL Regex to not require Imgur

### DIFF
--- a/common/src/main/generated/resources/assets/ad_astra/lang/en_us.json
+++ b/common/src/main/generated/resources/assets/ad_astra/lang/en_us.json
@@ -401,6 +401,7 @@
   "block.ad_astra.yellow_flag": "Yellow Flag",
   "block.ad_astra.yellow_industrial_lamp": "Yellow Industrial Lamp",
   "config.ad_astra.allowFlagImages": "Allow flag images",
+  "config.ad_astra.allowedFlagHosts": "Allowed flag hosts",
   "config.ad_astra.atmosphereLeave": "Atmosphere leave",
   "config.ad_astra.client.title": "Ad Astra Client",
   "config.ad_astra.clientConfig": "Client Config",

--- a/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class FlagUrlScreen extends Screen {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://i\\.imgur\\.com/(\\w+)\\.(png|jpeg|jpg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpe?g|webp|gif)$");
 
     private final BlockPos pos;
     private EditBox urlField;

--- a/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class FlagUrlScreen extends Screen {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com|i\\.ibb\\.co)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     private final BlockPos pos;
     private EditBox urlField;

--- a/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class FlagUrlScreen extends Screen {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpg|jpeg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     private final BlockPos pos;
     private EditBox urlField;

--- a/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
@@ -1,8 +1,10 @@
 package earth.terrarium.adastra.client.screens.blocks;
 
+import earth.terrarium.adastra.common.config.AdAstraConfig;
 import earth.terrarium.adastra.common.constants.ConstantComponents;
 import earth.terrarium.adastra.common.network.NetworkHandler;
 import earth.terrarium.adastra.common.network.packets.ServerboundSetFlagUrlPacket;
+import earth.terrarium.adastra.common.utils.ImageHostUtils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -15,8 +17,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 public class FlagUrlScreen extends Screen {
-
-    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com|i\\.ibb\\.co)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     private final BlockPos pos;
     private EditBox urlField;
@@ -36,16 +36,16 @@ public class FlagUrlScreen extends Screen {
         int x = this.width / 2 - 100;
         int y = this.height / 2 - 20;
         this.button = addRenderableWidget(new Button(x + 50, y + 30, 100, 20, ConstantComponents.CONFIRM, (button) -> {
-            var matcher = URL_REGEX.matcher(this.urlField.getValue());
-            if (matcher.matches()) {
-                NetworkHandler.CHANNEL.sendToServer(new ServerboundSetFlagUrlPacket(this.pos, matcher.group()));
+            String url = this.urlField.getValue();
+            if (ImageHostUtils.isValidFlagImageURL(url)) {
+                NetworkHandler.CHANNEL.sendToServer(new ServerboundSetFlagUrlPacket(this.pos, url));
                 this.onClose();
             }
         }, Supplier::get) {});
         button.active = false;
         urlField = addRenderableWidget(new EditBox(font, x, y, 200, 20, Component.literal("https://imgur.com/urURL")));
         urlField.setResponder(url -> {
-            if (URL_REGEX.matcher(url).matches()) {
+            if (ImageHostUtils.isValidFlagImageURL(url)) {
                 this.button.active = true;
                 this.urlField.setTextColor(0x00FF00);
             } else {

--- a/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
+++ b/common/src/main/java/earth/terrarium/adastra/client/screens/blocks/FlagUrlScreen.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 public class FlagUrlScreen extends Screen {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpe?g|webp|gif)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpg|jpeg|webp)$");
 
     private final BlockPos pos;
     private EditBox urlField;

--- a/common/src/main/java/earth/terrarium/adastra/common/config/AdAstraConfig.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/config/AdAstraConfig.java
@@ -25,6 +25,14 @@ public final class AdAstraConfig {
     public static boolean allowFlagImages = true;
 
     @ConfigEntry(
+        id = "allowedFlagHosts",
+        type = EntryType.STRING,
+        translation = "config.ad_astra.allowedFlagHosts"
+    )
+    @Comment("A comma-separated list of hostnames that are allowed for custom flag images. e.g. i.imgur.com, i.ibb.co, i.gyazo.com, raw.githubusercontent.com")
+    public static String allowedFlagHosts = "i.imgur.com, i.ibb.co, images2.imgbox.com, i.postimg.cc, prnt.sc, files.catbox.moe, i.gyazo.com, cdn.nest.rip, raw.githubusercontent.com, i.ibb.co";
+
+    @ConfigEntry(
         id = "launchAnywhere",
         type = EntryType.BOOLEAN,
         translation = "config.ad_astra.launchFromAnywhere"

--- a/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
@@ -10,6 +10,7 @@ import com.teamresourceful.resourcefullib.common.network.defaults.CodecPacketTyp
 import earth.terrarium.adastra.AdAstra;
 import earth.terrarium.adastra.common.blockentities.flag.FlagBlockEntity;
 import earth.terrarium.adastra.common.blockentities.flag.content.UrlContent;
+import earth.terrarium.adastra.common.utils.ImageHostUtils;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
@@ -19,8 +20,6 @@ import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 public record ServerboundSetFlagUrlPacket(BlockPos pos, String url) implements Packet<ServerboundSetFlagUrlPacket> {
-
-    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com|i\\.ibb\\.co)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     public static final ServerboundPacketType<ServerboundSetFlagUrlPacket> TYPE = new Type();
 
@@ -46,7 +45,7 @@ public record ServerboundSetFlagUrlPacket(BlockPos pos, String url) implements P
         @Override
         public Consumer<Player> handle(ServerboundSetFlagUrlPacket packet) {
             return player -> {
-                if (URL_REGEX.matcher(packet.url()).matches()
+                if (ImageHostUtils.isValidFlagImageURL(packet.url())
                     && player.distanceToSqr(packet.pos().getCenter()) <= 64
                     && player.level().getBlockEntity(packet.pos()) instanceof FlagBlockEntity flag
                     && flag.getOwner() != null

--- a/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public record ServerboundSetFlagUrlPacket(BlockPos pos, String url) implements Packet<ServerboundSetFlagUrlPacket> {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com|i\\.ibb\\.co)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     public static final ServerboundPacketType<ServerboundSetFlagUrlPacket> TYPE = new Type();
 

--- a/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public record ServerboundSetFlagUrlPacket(BlockPos pos, String url) implements Packet<ServerboundSetFlagUrlPacket> {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpg|jpeg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://(i\\.imgur\\.com|i\\.ibb\\.co|images2\\.imgbox\\.com|i\\.postimg\\.cc|prnt\\.sc|files\\.catbox\\.moe|i\\.gyazo\\.com|cdn\\.nest\\.rip|raw\\.githubusercontent\\.com)/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*\\.(png|jpeg|jpg|webp)$");
 
     public static final ServerboundPacketType<ServerboundSetFlagUrlPacket> TYPE = new Type();
 

--- a/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/network/packets/ServerboundSetFlagUrlPacket.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public record ServerboundSetFlagUrlPacket(BlockPos pos, String url) implements Packet<ServerboundSetFlagUrlPacket> {
 
-    private static final Pattern URL_REGEX = Pattern.compile("^https://i\\.imgur\\.com/(\\w+)\\.(png|jpeg|jpg|webp)$");
+    private static final Pattern URL_REGEX = Pattern.compile("^https://[\\w\\-.]+(?:/[\\w\\-._~:/?#\\[\\]@!$&'()*+,;=%]*)?\\.(png|jpg|jpeg|webp)$");
 
     public static final ServerboundPacketType<ServerboundSetFlagUrlPacket> TYPE = new Type();
 

--- a/common/src/main/java/earth/terrarium/adastra/common/utils/ImageHostUtils.java
+++ b/common/src/main/java/earth/terrarium/adastra/common/utils/ImageHostUtils.java
@@ -1,0 +1,37 @@
+package earth.terrarium.adastra.common.utils;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import earth.terrarium.adastra.common.config.AdAstraConfig;
+
+public class ImageHostUtils {
+    private static final Set<String> ALLOWED_EXTENSIONS = Set.of(
+        "png", "jpeg", "jpg", "webp"
+    );
+
+    public static Set<String> getAllowedHosts() {
+        return Arrays.stream(AdAstraConfig.allowedFlagHosts
+            .split(",")
+        ).map(String::trim).collect(Collectors.toUnmodifiableSet());
+    }   
+
+    public static Set<String> getAllowedExtensions() {
+        return ImageHostUtils.ALLOWED_EXTENSIONS;
+    }
+
+    public static boolean isValidFlagImageURL(String url) {
+        try {
+            URI uri = URI.create(url);
+            if (!"https".equals(uri.getScheme())) return false;
+            if (getAllowedHosts().contains(uri.getHost())) return false;
+            String path = uri.getPath().toLowerCase();
+            return ALLOWED_EXTENSIONS.stream().anyMatch(ext -> path.endsWith("." + ext));
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+}


### PR DESCRIPTION
The flag images only supports imgur, which blocks the UK. This will lead to [situations like this one](https://www.reddit.com/r/feedthebeast/comments/1u8hi54/any_way_around_ad_astra_flags_requiring_imgur_for/).

This PR changes the regex to be a more general one supporting any domain as long as it has the file extension, so a user can use an alternative host like [Catbox](https://catbox.moe) with less restrictions.