### PR TITLE
Fix Etrionic Blast Furnace dupe (Closes #694)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,1 +1,1 @@
-- Fix some block/item models not rendering correctly in Fabric (MrBysco)
+- Fix issues with the Etrionic Blast Furnace (MrBysco)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.caching=true
 
-version=1.16.24
+version=1.16.25
 group=earth.terrarium.adastra
 
 minecraftVersion=1.21.1

--- a/src/main/java/earth/terrarium/adastra/common/blockentities/machines/EtrionicBlastFurnaceBlockEntity.java
+++ b/src/main/java/earth/terrarium/adastra/common/blockentities/machines/EtrionicBlastFurnaceBlockEntity.java
@@ -137,19 +137,21 @@ public class EtrionicBlastFurnaceBlockEntity extends EnergyContainerMachineBlock
         boolean shouldClear = true;
         for (int i = 0; i < 4; i++) {
             if (recipes[i] == null) continue;
-            if (canCraft(energyStorage, recipes[i], i + 1)) {
-                shouldClear = false;
-            }
+            if (!canCraft(energyStorage, recipes[i], i + 1)) continue;
+            shouldClear = false;
             energyStorage.extract(MachineConfig.etrionicBlastFurnaceBlastingEnergyPerItem, false);
             UpdateManager.batch(energyStorage);
             isCooking = true;
-            if (cookTime < cookTimeTotal) continue;
-            for (int j = 0; j < 4; j++) {
-                craft(recipes[j], j + 1);
-            }
         }
         if (isCooking) {
             cookTime++;
+        }
+        if (cookTime >= cookTimeTotal && cookTimeTotal > 0) {
+            for (int j = 0; j < 4; j++) {
+                if (recipes[j] != null && canCraft(energyStorage, recipes[j], j + 1)) {
+                    craft(recipes[j], j + 1);
+                }
+            }
         }
         if (shouldClear) {
             for (int i = 0; i < 4; i++) {
@@ -230,7 +232,11 @@ public class EtrionicBlastFurnaceBlockEntity extends EnergyContainerMachineBlock
     }
 
     protected void createRecipe(int recipe, int slot) {
-        if (getItem(slot).isEmpty()) return;
+        if (getItem(slot).isEmpty() || (recipes[recipe] != null && !recipes[recipe].getIngredients().get(0).test(getItem(slot)))) {
+            recipes[recipe] = null;
+            return;
+        }
+        if (recipes[recipe] != null) return;
         level().getRecipeManager().getAllRecipesFor(RecipeType.BLASTING)
             .stream()
             .filter(r -> r.value().getIngredients().get(0).test(getItem(slot)))


### PR DESCRIPTION
The furnace will now craft each slot once per tick and making sure to clear the cached recipe when the item is removed.

This PR resolves #694 , #777